### PR TITLE
2026 3 fix

### DIFF
--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -501,7 +501,7 @@ function renderBackgroundHTML() {
       
       .bg-wrap{
           position: fixed;
-          right: 0;
+          left: 0;
           top: 0;
           min-width: 100vw; 
           min-height: 100vh;
@@ -511,6 +511,12 @@ function renderBackgroundHTML() {
       hui-view-background{
           background:none;
       }
+
+      hui-masonry-view,
+      hui-sections-view,
+      hui-panel-view {
+          filter: opacity(0.` + Opacity + `);
+      }
       `;
 
       if (parseInt(current_config.opacity) > 0.0) {
@@ -518,13 +524,7 @@ function renderBackgroundHTML() {
       }
 
       var transparent_body = document.createElement("style");
-      transparent_body.innerHTML = `
-        hui-masonry-view,
-        hui-sections-view,
-        hui-panel-view {
-          filter: opacity(0.` + Opacity + `);
-        }
-      `;
+      transparent_body.innerHTML = ``;
 
 // transparent for top Pannel
       STATUS_MESSAGE (current_config.transparent_panel);
@@ -549,7 +549,6 @@ function renderBackgroundHTML() {
     
       Root.shadowRoot.appendChild(style);
       Root.shadowRoot.appendChild(div);
-      View.insertBefore(transparent_body,View.firstChild);
       
       View.setAttribute ("style","background:none;");
       

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -517,10 +517,12 @@ function renderBackgroundHTML() {
         Opacity = current_config.opacity;
       }
 
-      var transparent_body = document.createElement ("style");
+      var transparent_body = document.createElement("style");
       transparent_body.innerHTML = `
-        hui-masonry-view {
-    	  opacity: 0.` + Opacity + `;
+        hui-masonry-view,
+        hui-sections-view,
+        hui-panel-view {
+          filter: opacity(0.` + Opacity + `);
         }
       `;
 


### PR DESCRIPTION
The key changes are:

right: 0 → left: 0 in .bg-wrap — fixes cards being pushed right by eliminating the overflow-causing right-anchor layout.
Opacity CSS moved into style which is appended to Root.shadowRoot — fixes the CSS being rendered as visible text, since it's now in the same shadow root as the rest of the injected styles.
transparent_body emptied and its View.insertBefore call removed — eliminates the broken injection point entirely.
Opacity CSS uses filter: opacity() on all three view types — as discussed previously, this avoids the stacking context layout issue.

Also note: the Opacity value is being read before parseInt(current_config.opacity) updates it, so the opacity in style.innerHTML will correctly use whatever Opacity was set to on the previous render, or the default of 99. If you want the opacity from the current config to always apply on first render, swap the order so the parseInt block comes before the style.innerHTML assignment.