### PR TITLE
Code cleanup

### DIFF
--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -11,7 +11,7 @@ var Animated_Config;
 var Haobj = null;
 var View;
 var Panel_Holder;
-var Debug_Mode = true;
+var Debug_Mode = false;
 var Loaded = false;
 var View_Loaded = false;
 var Meme_Remover = null;
@@ -527,16 +527,19 @@ function renderBackgroundHTML() {
       transparent_body.innerHTML = ``;
 
 // transparent for top Pannel
-      STATUS_MESSAGE (current_config.transparent_panel);
       if (current_config.transparent_panel) {
         var html_element = document.querySelector("html");
-        html_element.style.removeProperty ('--app-header-background-color');
-      
-        var ha_style = `<style>
-    	    html {
-    		--primary-color:initial;
-    	    }`;
-        Header.insertAdjacentHTML('beforeBegin',ha_style);
+        html_element.style.removeProperty('--app-header-background-color');
+
+        if (!document.getElementById('animated-bg-panel-style')) {
+          var ha_style = document.createElement('style');
+          ha_style.id = 'animated-bg-panel-style';
+          ha_style.innerHTML = `
+            html {
+              --primary-color: initial;
+            }`;
+          document.head.appendChild(ha_style);
+        }
       }
 
       var div = document.createElement("div");
@@ -668,6 +671,17 @@ function setDebugMode() {
   }
 }
 
+function cleanupDOM() {
+  if (Root && Root.shadowRoot) {
+    var oldDiv = Root.shadowRoot.getElementById('background-video');
+    if (oldDiv) oldDiv.remove();
+    var oldStyles = Root.shadowRoot.querySelectorAll('style');
+    oldStyles.forEach(function(s) { s.remove(); });
+  }
+  var panelStyle = document.getElementById('animated-bg-panel-style');
+  if (panelStyle) panelStyle.remove();
+}
+
 //main function
 function run() {
   getVars();
@@ -746,6 +760,7 @@ function run() {
 }
 
 function restart() {
+  cleanupDOM();
   clearInterval(wait_interval);
   var wait_interval = setInterval(() => {
     getVars()

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -501,7 +501,7 @@ function renderBackgroundHTML() {
       
       .bg-wrap{
           position: fixed;
-          right: 0;
+          left: 0;
           top: 0;
           min-width: 100vw; 
           min-height: 100vh;
@@ -511,6 +511,12 @@ function renderBackgroundHTML() {
       hui-view-background{
           background:none;
       }
+
+      hui-masonry-view,
+      hui-sections-view,
+      hui-panel-view {
+          filter: opacity(0.` + Opacity + `);
+      }
       `;
 
       if (parseInt(current_config.opacity) > 0.0) {
@@ -518,13 +524,7 @@ function renderBackgroundHTML() {
       }
 
       var transparent_body = document.createElement("style");
-      transparent_body.innerHTML = `
-        hui-masonry-view,
-        hui-sections-view,
-        hui-panel-view {
-          filter: opacity(0.` + Opacity + `);
-        }
-      `;
+      transparent_body.innerHTML = ``;
 
 // transparent for top Pannel
       STATUS_MESSAGE (current_config.transparent_panel);
@@ -549,7 +549,6 @@ function renderBackgroundHTML() {
     
       Root.shadowRoot.appendChild(style);
       Root.shadowRoot.appendChild(div);
-      View.insertBefore(transparent_body,View.firstChild);
       
       View.setAttribute ("style","background:none;");
       

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -517,10 +517,12 @@ function renderBackgroundHTML() {
         Opacity = current_config.opacity;
       }
 
-      var transparent_body = document.createElement ("style");
+      var transparent_body = document.createElement("style");
       transparent_body.innerHTML = `
-        hui-masonry-view {
-    	  opacity: 0.` + Opacity + `;
+        hui-masonry-view,
+        hui-sections-view,
+        hui-panel-view {
+          filter: opacity(0.` + Opacity + `);
         }
       `;
 


### PR DESCRIPTION
I was having an issue where the iOS themes were not being applied (intermittent).

These changes include:

Replaced repeated insertAdjacentHTML panel style injection with a single createElement approach using a stable ID (animated-bg-panel-style) to prevent duplicate injection
Added cleanupDOM() function to remove injected background div, style elements, and the panel style on restart
Called cleanupDOM() at the start of restart() to ensure a clean slate on dashboard and panel changes
Changed Debug_Mode default to false