### PR TITLE
Refresh frequency

### DIFF
--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -16,6 +16,7 @@ var Loaded = false;
 var View_Loaded = false;
 var Meme_Remover = null;
 var Meme_Count = 0;
+var Refresh_Timer = null;
 var Opacity = 99;
 
 //state tracking variables
@@ -88,6 +89,7 @@ var View_Observer = new MutationObserver(function (mutations) {
       }
       View_Loaded = false;
       clearMemes();
+      clearRefreshTimer();
       renderBackgroundHTML();
     }
   });
@@ -439,6 +441,16 @@ function renderBackgroundHTML() {
 
   Previous_Config = current_config;
 
+  if (current_config.refresh_interval && !Refresh_Timer) {
+    Refresh_Timer = setInterval(function() {
+      Previous_State = null;
+      Previous_Url = null;
+      renderBackgroundHTML();
+    }, current_config.refresh_interval * 60 * 1000);
+  } else if (!current_config.refresh_interval) {
+    clearRefreshTimer();
+  }
+
   var html_to_render;
   if (state_url != "" && Hui) {
     var bg = Hui.shadowRoot.getElementById("background-iframe");
@@ -683,6 +695,11 @@ function clearMemes() {
   Meme_Remover = null;
 }
 
+function clearRefreshTimer() {
+  clearInterval(Refresh_Timer);
+  Refresh_Timer = null;
+}
+
 function setDebugMode() {
   if (Animated_Config) {
     if (Animated_Config.debug) {
@@ -801,6 +818,7 @@ function run() {
 
 function restart() {
   cleanupDOM();
+  clearRefreshTimer();
   clearInterval(wait_interval);
   var wait_interval = setInterval(() => {
     getVars()

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -23,6 +23,7 @@ let Previous_State;
 let Previous_Entity;
 let Previous_Url;
 let Previous_Config;
+let Previous_Last_Updated;
 
 function STATUS_MESSAGE(message, force) {
   if (!Debug_Mode) {
@@ -378,6 +379,9 @@ function renderBackgroundHTML() {
             }
           }
           Previous_State = current_state;
+          if (Haobj && Haobj.states[current_config.entity]) {
+            Previous_Last_Updated = Haobj.states[current_config.entity].last_updated;
+          }
         }
       }
       else {
@@ -740,7 +744,14 @@ function run() {
         if (Loaded) {
           if (current_config && current_config.entity) {
             var current_state = getEntityState(current_config.entity);
-            if (Previous_State != current_state) {
+            var entity_data = Haobj.states[current_config.entity];
+            var current_last_updated = entity_data ? entity_data.last_updated : null;
+            var state_changed = Previous_State != current_state;
+            var force_refresh = current_config.refresh_on_update && current_last_updated !== Previous_Last_Updated;
+            if (state_changed || force_refresh) {
+              if (force_refresh && !state_changed) {
+                Previous_State = null;
+              }
               clearMemes();
               renderBackgroundHTML();
             }
@@ -796,6 +807,7 @@ function restart() {
     if (Hui) {
       Previous_Entity = null;
       Previous_State = null;
+      Previous_Last_Updated = null;
       Loaded = false;
       View_Loaded = false;
       clearMemes();


### PR DESCRIPTION
added two options that will make it refresh sooner then on weather change, to give more variation on the background.

option 1:
refresh_on_update: true
this picks a new background if the last update value of the weather entity changes even if the condition does not.

option 2:
refresh_interval: 5
pick a new background every X minute as defined above

both options are optional and not defining them should keep current behaviour.