### PR TITLE
feat/Add custom overlay - Add UI editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-*.txt

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project builds on the work of several contributors:
 ### Method 2: Manual
 
 1. Copy `animated-background.js` from this repository to `<config directory>/www/animated-background.js` on your Home Assistant instance.
-2. Register the resource — see [Registering the resource](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#registering-the-resource) below.
+2. Register the resource — see **Registering the resource** below.
 
 **Registering the resource**
 
@@ -87,11 +87,11 @@ All options go under the `animated_background:` key at the root of your Lovelace
 | `enabled` | bool | Set to `false` to disable the plugin entirely. Default: `true`. |
 | `entity` | string | Home Assistant entity whose state drives background changes. |
 | `state_url` | map | Map of entity states to video or image URLs. Each value can be a single URL or a list. Set a state to `'none'` to disable the background for that state. Required if `entity` is set. |
-| `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#troubleshooting-popups-appear-behind-the-background). |
+| `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](#troubleshooting-popups-appear-behind-the-background). |
 | `overlay` | map | Optional tint layer drawn over the background media. Takes `color` (any CSS color, default `#000000`) and `opacity` (0–1, default `0.3`). Darkens or tints busy backgrounds so cards and text stay readable. Can be set at the root, group, or view level. |
 | `transparent_panel` | bool | Makes the top navigation panel/header transparent. Default: `false`. |
-| `views` | list | Per-view configuration overrides. See [View Configuration](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#view-configuration). |
-| `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#group-configuration). |
+| `views` | list | Per-view configuration overrides. See [View Configuration](#view-configuration). |
+| `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](#group-configuration). |
 | `included_users` | list of strings | Only these users will see the animated background. All others are excluded. |
 | `excluded_users` | list of strings | These users will not see the animated background. |
 | `included_devices` | list of strings | Only these device types will show the background. Supported values: `iphone`, `ipad`, `windows`, `macintosh`, `android`. |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project builds on the work of several contributors:
 ### Method 2: Manual
 
 1. Copy `animated-background.js` from this repository to `<config directory>/www/animated-background.js` on your Home Assistant instance.
-2. Register the resource — see [Registering the resource](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#registering-the-resource) below.
+2. Register the resource — see **Registering the resource** below.
 
 **Registering the resource**
 
@@ -87,10 +87,10 @@ All options go under the `animated_background:` key at the root of your Lovelace
 | `enabled` | bool | Set to `false` to disable the plugin entirely. Default: `true`. |
 | `entity` | string | Home Assistant entity whose state drives background changes. |
 | `state_url` | map | Map of entity states to video or image URLs. Each value can be a single URL or a list. Set a state to `'none'` to disable the background for that state. Required if `entity` is set. |
-| `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#troubleshooting-popups-appear-behind-the-background). |
+| `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](#troubleshooting-popups-appear-behind-the-background). |
 | `transparent_panel` | bool | Makes the top navigation panel/header transparent. Default: `false`. |
-| `views` | list | Per-view configuration overrides. See [View Configuration](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#view-configuration). |
-| `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#group-configuration). |
+| `views` | list | Per-view configuration overrides. See [View Configuration](#view-configuration). |
+| `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](#group-configuration). |
 | `included_users` | list of strings | Only these users will see the animated background. All others are excluded. |
 | `excluded_users` | list of strings | These users will not see the animated background. |
 | `included_devices` | list of strings | Only these device types will show the background. Supported values: `iphone`, `ipad`, `windows`, `macintosh`, `android`. |

--- a/README.md
+++ b/README.md
@@ -326,6 +326,24 @@ animated_background:
 
 ---
 
+## Visual Editor
+
+Don't want to hand-edit YAML? The plugin ships a visual editor card in the same file — no extra resource needed.
+
+1. Edit any dashboard and add a card. Find **Animated Background Editor** in the custom cards picker (or use Manual card and type `custom:animated-background-editor`).
+2. Place it on the dashboard you want to configure — ideally a private/admin view, since it's a tool rather than a decoration.
+3. Edit the configuration across the tabs: **General** (default URL, opacity, overlay, refresh), **Entity & States**, **Views**, **Groups**, **Access** (user/device include/exclude), and **Advanced** (debug).
+4. Click **Save**. On storage-mode dashboards (dashboards managed through the Home Assistant UI) the configuration is written directly and the background redraws immediately. View→group assignments are written onto the matching view definitions for you.
+
+**Notes:**
+
+- On YAML-mode dashboards, saving is not possible from the card. In that case the editor generates the `animated_background:` block (plus the view-level lines) for you to copy into your configuration file.
+- **Copy YAML** always works — it produces the `animated_background:` block for the current form, which is handy for sharing a configuration or keeping one in a YAML repo.
+- The editor only touches the `animated_background:` root key and the `animated_background:` key on view definitions. Everything else in your dashboard config is preserved untouched.
+- If a `views:` entry references a view path that no longer exists, the editor shows it as a stale entry so you can delete it.
+
+---
+
 ## Troubleshooting: Popups appear behind the background
 
 If you use **Bubble Card** or similar popup integrations and notice popups opening behind the background, this is a CSS stacking context issue caused by the `opacity` option.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ All options go under the `animated_background:` key:
 | `transparent_panel` | bool | Makes the top navigation panel/header transparent. Default: `false`. |
 | `views` | list | Per-view configuration overrides. See [View Configuration](#view-configuration). |
 | `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](#group-configuration). |
-| `included_users` | list of strings | Only these users will see the animated background. All others are excluded. |
-| `excluded_users` | list of strings | These users will not see the animated background. |
+| `included_users` | list of strings | Only these users will see the animated background. All others are excluded. See the precedence rules below. |
+| `excluded_users` | list of strings | These users will not see the animated background. Exclusions always win. |
 | `included_devices` | list of strings | Only these device types will show the background. Supported values: `iphone`, `ipad`, `windows`, `macintosh`, `android`. |
-| `excluded_devices` | list of strings | These device types will not show the background. |
+| `excluded_devices` | list of strings | These device types will not show the background. Exclusions always win. |
 | `debug` | bool | Enables detailed console logging. |
 | `display_user_agent` | bool | Shows an alert with your current user agent string. Useful for determining the correct value to use in device include/exclude lists. |
 | `refresh_on_update` | bool | Refreshes the background when the updated state of the weather entity changes even if the value does not. |
@@ -144,6 +144,11 @@ All options go under the `animated_background:` key:
 > **Note on `opacity`:** The `opacity` setting makes the entire view container semi-transparent, which only produces a see-through card effect when combined with a theme that sets `--ha-card-background` to a transparent or semi-transparent colour (e.g. `rgba(0,0,0,0.3)`). Without a compatible theme, cards will appear faded but not transparent. Several HACS themes (such as iOS themes) provide this out of the box.
 
 > **Note on root fallback:** `opacity`, `overlay`, `background`, `transparent_panel`, `refresh_interval` and `refresh_on_update` are read from the active view or group config first, and fall back to the root `animated_background:` config when the view or group does not set them. You do not need to repeat them inside each group definition — but you can override them per group or view.
+
+> **Access precedence:** include/exclude lists are evaluated in a fixed order.
+> 1. **Exclusions always win.** A user or device matching any `excluded_users` or `excluded_devices` list (root *or* view/group config) never sees the background, regardless of inclusion lists or `enabled: true`.
+> 2. An explicit `enabled: true` or `enabled: false` on a view or group config applies next. It can override inclusion lists, never exclusions.
+> 3. If any `included_users` or `included_devices` list is configured, the current user or device must match at least one of them to see the background. With no inclusion lists configured, everyone (not excluded by step 1) sees it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
 
-Animated video and image backgrounds for Home Assistant Lovelace dashboards, with support for entity-driven state changes, per-view configuration, transparent panels, and card opacity.
+Animated video and image backgrounds for Home Assistant Lovelace dashboards, with support for entity-driven state changes, per-view configuration, transparent panels, card opacity, and a built-in visual editor.
 
 ![Example](https://raw.githubusercontent.com/Villhellm/README_images/master/Animation.gif)
 
@@ -15,7 +15,7 @@ This project builds on the work of several contributors:
 - **[Villhellm](https://github.com/Villhellm/lovelace-animated-background)** — original author. May he rest in peace.
 - **[dreimer1986](https://github.com/dreimer1986/lovelace-animated-background)** — fixes for Home Assistant 2023.04.0 and transparent card mode.
 - **[rbogdanov](https://github.com/rbogdanov/lovelace-animated-background)** — added transparent panel support and card opacity mode.
-- **[imonlinux](https://github.com/imonlinux/lovelace-animated-background)** — fixes for HA 2026.x, layout and CSS stacking context fixes, shadow DOM targeting corrections, and group config inheritance fixes.
+- **[imonlinux](https://github.com/imonlinux/lovelace-animated-background)** — fixes for HA 2026.x, layout and CSS stacking context fixes, shadow DOM targeting corrections, group config inheritance fixes, and the visual editor.
 
 ---
 
@@ -50,7 +50,52 @@ Navigate to **Settings → Dashboards**, then open the **three-dot menu (⋮)** 
 
 ---
 
-## Setup
+## Configure with the visual editor
+
+The plugin ships a visual editor card **in the same file** — no extra install, no second resource. If the background is installed, the editor is already available. It configures the entire `animated_background:` block through a form and writes it back to the dashboard, so you never have to touch YAML unless you want to.
+
+### Adding the editor card to an existing dashboard
+
+1. Open the dashboard and select the **pencil icon** (Edit dashboard).
+2. Select **Add card**, then search for **Animated Background Editor**. (Alternatively choose **Manual** and enter `type: custom:animated-background-editor`.)
+3. Place it on an admin or private view — it is a configuration tool, not a decoration. Any view on the dashboard works; the editor configures the whole dashboard, not the view it sits on.
+4. Select **Done** to leave edit mode.
+5. Configure across the tabs and select **Save**. The background redraws immediately.
+
+### Setting up a brand-new dashboard
+
+1. Go to **Settings → Dashboards → + Add Dashboard**, choose **New dashboard from scratch**, give it a title, then **Create** and open it.
+2. **Take control of the dashboard.** Select the pencil icon; a new dashboard is auto-populated by a strategy and Home Assistant will prompt you to take control. Confirm (choosing to start from the auto-generated cards or an empty dashboard — either is fine).
+   > **This step is required.** Until you take control, the dashboard has no stored configuration for the editor to write to, and saving will not work. The editor detects this and tells you.
+3. Add the editor card as in the steps above.
+4. Configure and save.
+
+> The resource only needs registering once for your whole Home Assistant instance, not per dashboard. If the background already works on one dashboard, the editor card is available on all of them.
+
+### What each tab does
+
+| Tab | What you set there |
+| --- | --- |
+| General | Default background URL(s), tint overlay, card opacity, transparent header, refresh behaviour |
+| Entity & States | The entity that drives the background, and a URL for each of its states |
+| Views | Per-view overrides — inherit, use a group, disable, or set a custom config |
+| Groups | Named reusable configs you can assign to multiple views |
+| Access | Limit the background to specific users or device types |
+| Advanced | Debug logging, user-agent display, and the generated YAML |
+
+### Good to know
+
+- Entering **multiple URLs** — one per line in a URL box — means one is picked at random each refresh.
+- **Saving requires admin.** Non-admin users see the generated YAML instead.
+- **YAML-mode dashboards** cannot be saved from the card; the editor generates the `animated_background:` block plus the view-level assignment lines to paste in.
+- **Copy YAML** always works — useful for sharing a config or keeping one in a repo.
+- The editor **preserves everything else** in the dashboard config; it only touches the `animated_background:` keys.
+- **Stale view entries** (referencing a view path that no longer exists) are flagged so they can be removed.
+- Removing the editor card does not affect the background — the config stays.
+
+---
+
+## Configuration Reference
 
 Add the `animated_background:` block at the **root** of your Lovelace dashboard configuration — not inside a view or card. If you are using UI-managed dashboards, access the raw configuration editor via the **pencil icon → three-dot menu → Edit in YAML** on your dashboard.
 
@@ -72,14 +117,8 @@ views: ...
 ```
 
 > Any `mp4`, `webm`, or image URL will work, including local `/local/` paths. Using locally stored videos is strongly recommended — it greatly improves loading times and avoids dependence on external CDNs. Short looping videos ("cinemagraphs") work best.
-> 
-> **See the example configuration below.**
 
----
-
-## Configuration Reference
-
-All options go under the `animated_background:` key at the root of your Lovelace dashboard config.
+All options go under the `animated_background:` key:
 
 | Option | Type | Description |
 | --- | --- | --- |
@@ -89,6 +128,7 @@ All options go under the `animated_background:` key at the root of your Lovelace
 | `state_url` | map | Map of entity states to video or image URLs. Each value can be a single URL or a list. Set a state to `'none'` to disable the background for that state. Required if `entity` is set. |
 | `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](#troubleshooting-popups-appear-behind-the-background). |
 | `overlay` | map | Optional tint layer drawn over the background media. Takes `color` (any CSS color, default `#000000`) and `opacity` (0–1, default `0.3`). Darkens or tints busy backgrounds so cards and text stay readable. Can be set at the root, group, or view level. |
+| `background` | string | CSS background override for the view behind the header. Defaults to `transparent` when the background is active. Set it to any CSS background value (for example a color) if you do not want the view fully see-through. |
 | `transparent_panel` | bool | Makes the top navigation panel/header transparent. Default: `false`. |
 | `views` | list | Per-view configuration overrides. See [View Configuration](#view-configuration). |
 | `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](#group-configuration). |
@@ -103,7 +143,7 @@ All options go under the `animated_background:` key at the root of your Lovelace
 
 > **Note on `opacity`:** The `opacity` setting makes the entire view container semi-transparent, which only produces a see-through card effect when combined with a theme that sets `--ha-card-background` to a transparent or semi-transparent colour (e.g. `rgba(0,0,0,0.3)`). Without a compatible theme, cards will appear faded but not transparent. Several HACS themes (such as iOS themes) provide this out of the box.
 
-> **Note on `transparent_panel` and `opacity` with groups:** These settings are always read from the root `animated_background:` config, even when a view is using a group configuration. You do not need to repeat them inside each group definition.
+> **Note on root fallback:** `opacity`, `overlay`, `background`, `transparent_panel`, `refresh_interval` and `refresh_on_update` are read from the active view or group config first, and fall back to the root `animated_background:` config when the view or group does not set them. You do not need to repeat them inside each group definition — but you can override them per group or view.
 
 ---
 
@@ -323,24 +363,6 @@ animated_background:
 ```
 
 > `overlay` tints the background media itself (a layer drawn on top of the video/image), while `opacity` makes the dashboard's cards semi-transparent. They're independent: use `overlay` to darken a bright background for readability, and `opacity` (with a compatible theme) to let the background show through cards.
-
----
-
-## Visual Editor
-
-Don't want to hand-edit YAML? The plugin ships a visual editor card in the same file — no extra resource needed.
-
-1. Edit any dashboard and add a card. Find **Animated Background Editor** in the custom cards picker (or use Manual card and type `custom:animated-background-editor`).
-2. Place it on the dashboard you want to configure — ideally a private/admin view, since it's a tool rather than a decoration.
-3. Edit the configuration across the tabs: **General** (default URL, opacity, overlay, refresh), **Entity & States**, **Views**, **Groups**, **Access** (user/device include/exclude), and **Advanced** (debug).
-4. Click **Save**. On storage-mode dashboards (dashboards managed through the Home Assistant UI) the configuration is written directly and the background redraws immediately. View→group assignments are written onto the matching view definitions for you.
-
-**Notes:**
-
-- On YAML-mode dashboards, saving is not possible from the card. In that case the editor generates the `animated_background:` block (plus the view-level lines) for you to copy into your configuration file.
-- **Copy YAML** always works — it produces the `animated_background:` block for the current form, which is handy for sharing a configuration or keeping one in a YAML repo.
-- The editor only touches the `animated_background:` root key and the `animated_background:` key on view definitions. Everything else in your dashboard config is preserved untouched.
-- If a `views:` entry references a view path that no longer exists, the editor shows it as a stale entry so you can delete it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All options go under the `animated_background:` key at the root of your Lovelace
 | `entity` | string | Home Assistant entity whose state drives background changes. |
 | `state_url` | map | Map of entity states to video or image URLs. Each value can be a single URL or a list. Set a state to `'none'` to disable the background for that state. Required if `entity` is set. |
 | `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#troubleshooting-popups-appear-behind-the-background). |
+| `overlay` | map | Optional tint layer drawn over the background media. Takes `color` (any CSS color, default `#000000`) and `opacity` (0–1, default `0.3`). Darkens or tints busy backgrounds so cards and text stay readable. Can be set at the root, group, or view level. |
 | `transparent_panel` | bool | Makes the top navigation panel/header transparent. Default: `false`. |
 | `views` | list | Per-view configuration overrides. See [View Configuration](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#view-configuration). |
 | `groups` | list | Named reusable configurations that views can reference. See [Group Configuration](https://claude.ai/chat/5905014c-aa85-4fb7-95c4-3943bd6d8557#group-configuration). |
@@ -306,6 +307,22 @@ animated_background:
 ```
 
 > `sun.sun` has two states — `above_horizon` (daytime) and `below_horizon` (night) — giving you four possible combinations to map backgrounds to.
+
+---
+
+### Tinting a busy background
+
+```yaml
+animated_background:
+  entity: weather.home
+  overlay:
+    color: "#000000"
+    opacity: 0.35
+  state_url:
+    sunny: /local/backgrounds/sunny/hlhff0h8md4ev0kju5be.hd.mp4
+```
+
+> `overlay` tints the background media itself (a layer drawn on top of the video/image), while `opacity` makes the dashboard's cards semi-transparent. They're independent: use `overlay` to darken a bright background for readability, and `opacity` (with a compatible theme) to let the background show through cards.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ All options go under the `animated_background:` key:
 | `enabled` | bool | Set to `false` to disable the plugin entirely. Default: `true`. |
 | `entity` | string | Home Assistant entity whose state drives background changes. |
 | `state_url` | map | Map of entity states to video or image URLs. Each value can be a single URL or a list. Set a state to `'none'` to disable the background for that state. Required if `entity` is set. |
-| `opacity` | number (0–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](#troubleshooting-popups-appear-behind-the-background). |
+| `opacity` | number (1–99) | Makes the view element semi-transparent so the background shows through cards. Requires a theme that sets card backgrounds to transparent or semi-transparent. **Note:** this creates a CSS stacking context — see [Troubleshooting](#troubleshooting-popups-appear-behind-the-background). |
 | `overlay` | map | Optional tint layer drawn over the background media. Takes `color` (any CSS color, default `#000000`) and `opacity` (0–1, default `0.3`). Darkens or tints busy backgrounds so cards and text stay readable. Can be set at the root, group, or view level. |
 | `background` | string | CSS background override for the view behind the header. Defaults to `transparent` when the background is active. Set it to any CSS background value (for example a color) if you do not want the view fully see-through. |
 | `transparent_panel` | bool | Makes the top navigation panel/header transparent. Default: `false`. |

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -463,7 +463,31 @@ function renderBackgroundHTML() {
       doc_body = `<img src='${state_url}'>`
     }
 
-    
+    // Optional tint overlay drawn above the media. Resolved from the current
+    // config, falling back to the root config — same pattern as opacity and
+    // transparent_panel. `color` is any CSS color; `opacity` is 0..1.
+    var overlay = current_config.overlay !== undefined
+      ? current_config.overlay
+      : (Animated_Config ? Animated_Config.overlay : null);
+    var overlay_style = "";
+    var overlay_html = "";
+    if (overlay && (overlay.color || overlay.opacity != null)) {
+      var overlay_color = overlay.color || "#000000";
+      var overlay_opacity = overlay.opacity != null ? overlay.opacity : 0.3;
+      overlay_style = `
+        #overlay {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: ${overlay_color};
+          opacity: ${overlay_opacity};
+          pointer-events: none;
+        }`;
+      overlay_html = `<div id='overlay'></div>`;
+    }
+
     var source_doc = `
     <html>
     <head>
@@ -499,10 +523,12 @@ function renderBackgroundHTML() {
           left: 50%;
           transform: translate(-50%, -50%);
         }
+        ${overlay_style}
       </style>
     </head>  
     <body id='source-body'>
     ${doc_body}
+    ${overlay_html}
     </body>
     </html>`;
     if (!bg) {

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -612,10 +612,16 @@ function renderBackgroundHTML() {
       var div = document.createElement("div");
       div.id = "background-video";
       div.className = "bg-wrap";
-      div.innerHTML = `
-       <iframe id="background-iframe" class="bg-video" frameborder="0" style="pointer-events:none;" srcdoc="${source_doc}"/>
-
-      `;
+      // Built via element properties, not HTML interpolation: a double
+      // quote in a URL or overlay color would truncate an interpolated
+      // srcdoc attribute and blank the background with no diagnostic.
+      var iframe = document.createElement("iframe");
+      iframe.id = "background-iframe";
+      iframe.className = "bg-video";
+      iframe.setAttribute("frameborder", "0");
+      iframe.style.pointerEvents = "none";
+      iframe.srcdoc = source_doc;
+      div.appendChild(iframe);
 
       Root.shadowRoot.appendChild(div);
 
@@ -914,7 +920,15 @@ function restart() {
   }, 200);
 }
 
-run();
+// Guard against double registration (e.g. a leftover /local/ resource plus
+// the /hacsfiles/ one): two copies would run competing observers and render
+// loops on the same DOM.
+if (window.__animatedBackgroundLoaded) {
+  console.warn(Log_Prefix + "already loaded; ignoring duplicate resource registration.");
+} else {
+  window.__animatedBackgroundLoaded = true;
+  run();
+}
 
 
 // ======================================================================

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -863,3 +863,1081 @@ function restart() {
 }
 
 run();
+
+// ======================================================================
+// Visual Configuration Editor
+//
+// Registers a `custom:animated-background-editor` card. Place it on any
+// view of the dashboard you want to configure. It reads the dashboard's
+// root `animated_background:` config, lets you edit it in a form, and
+// saves it back through hui-root's lovelace.saveConfig(). On YAML-mode
+// dashboards (where saveConfig is unavailable) it instead shows the
+// generated YAML block to copy into your configuration file.
+// ======================================================================
+(function () {
+  "use strict";
+
+  if (window.__animatedBackgroundEditorLoaded) {
+    return;
+  }
+  window.__animatedBackgroundEditorLoaded = true;
+
+  var KNOWN_DEVICES = ["iphone", "ipad", "windows", "macintosh", "android"];
+
+  // -------------------- pure helpers (also used by the smoke tests) ----
+
+  function splitLines(text) {
+    return String(text == null ? "" : text)
+      .split("\n")
+      .map(function (l) { return l.trim(); })
+      .filter(function (l) { return l.length > 0; });
+  }
+
+  // textarea content -> string | string[] | undefined (undefined = remove key)
+  function linesToUrlValue(text) {
+    var lines = splitLines(text);
+    if (lines.length === 0) return undefined;
+    if (lines.length === 1) return lines[0];
+    return lines;
+  }
+
+  // config value -> textarea content
+  function urlValueToLines(value) {
+    if (value == null) return "";
+    if (Array.isArray(value)) return value.join("\n");
+    return String(value);
+  }
+
+  // "a, b\nc" -> ["a", "b", "c"]
+  function textToList(text) {
+    return String(text == null ? "" : text)
+      .split(/[\n,]/)
+      .map(function (l) { return l.trim(); })
+      .filter(function (l) { return l.length > 0; });
+  }
+
+  function listToText(value) {
+    if (Array.isArray(value)) return value.join(", ");
+    if (value == null) return "";
+    return String(value);
+  }
+
+  function stateMapToRows(map) {
+    return Object.keys(map || {}).map(function (key) {
+      return { state: key, urls: urlValueToLines(map[key]) };
+    });
+  }
+
+  // state rows -> state_url map, or undefined when nothing is filled in
+  function rowsToStateMap(rows) {
+    var map = {};
+    (rows || []).forEach(function (row) {
+      var key = String(row.state || "").trim();
+      var value = linesToUrlValue(row.urls);
+      if (key && value !== undefined) {
+        map[key] = value;
+      }
+    });
+    return Object.keys(map).length > 0 ? map : undefined;
+  }
+
+  // sub-config (group/view config) -> editable sub-form
+  function subFormFromConfig(cfg) {
+    cfg = cfg || {};
+    var overlay = cfg.overlay || {};
+    return {
+      entity: cfg.entity || "",
+      default_url: urlValueToLines(cfg.default_url),
+      states: stateMapToRows(cfg.state_url),
+      overlay_enabled: !!cfg.overlay,
+      overlay_color: overlay.color || "#000000",
+      overlay_opacity: overlay.opacity != null ? String(overlay.opacity) : "0.3"
+    };
+  }
+
+  // editable sub-form -> sub-config, or null when the form is empty
+  function subConfigFromForm(sf) {
+    if (!sf) return null;
+    var cfg = {};
+    if (String(sf.entity || "").trim()) cfg.entity = String(sf.entity).trim();
+    var default_url = linesToUrlValue(sf.default_url);
+    if (default_url !== undefined) cfg.default_url = default_url;
+    var state_url = rowsToStateMap(sf.states);
+    if (state_url) cfg.state_url = state_url;
+    if (sf.overlay_enabled) {
+      var parsed = parseFloat(sf.overlay_opacity);
+      cfg.overlay = {
+        color: String(sf.overlay_color || "#000000"),
+        opacity: isNaN(parsed) ? 0.3 : Math.min(1, Math.max(0, parsed))
+      };
+    }
+    return Object.keys(cfg).length > 0 ? cfg : null;
+  }
+
+  // root config + lovelace views -> full editable form
+  function formFromConfig(cfg, lovelaceViews) {
+    cfg = cfg || {};
+    var overlay = cfg.overlay || {};
+
+    var customByPath = {};
+    (cfg.views || []).forEach(function (entry) {
+      if (entry && entry.path != null && entry.config) {
+        customByPath[String(entry.path)] = entry.config;
+      }
+    });
+
+    var seen = {};
+    var views = [];
+    (lovelaceViews || []).forEach(function (view, index) {
+      var path = view.path != null ? String(view.path) : String(index);
+      seen[path] = true;
+      var assignment = view.animated_background;
+      var mode = "inherit";
+      var group = "";
+      var custom = null;
+      if (customByPath[path]) {
+        mode = "custom";
+        custom = subFormFromConfig(customByPath[path]);
+      } else if (assignment === "none") {
+        mode = "none";
+      } else if (typeof assignment === "string" && assignment) {
+        mode = "group";
+        group = assignment;
+      }
+      views.push({
+        path: path,
+        title: view.title || "",
+        mode: mode,
+        group: group,
+        orphan: false,
+        custom: custom || subFormFromConfig(null)
+      });
+    });
+    // root `views:` entries that no longer match a dashboard view (stale)
+    Object.keys(customByPath).forEach(function (path) {
+      if (!seen[path]) {
+        views.push({
+          path: path,
+          title: "(view not found in dashboard)",
+          mode: "custom",
+          group: "",
+          orphan: true,
+          custom: subFormFromConfig(customByPath[path])
+        });
+      }
+    });
+
+    var groups = (cfg.groups || []).map(function (group) {
+      return {
+        name: (group && group.name) || "",
+        custom: subFormFromConfig(group && group.config)
+      };
+    });
+
+    var opacity = cfg.opacity;
+    return {
+      enabled: cfg.enabled !== false,
+      default_url: urlValueToLines(cfg.default_url),
+      entity: cfg.entity || "",
+      states: stateMapToRows(cfg.state_url),
+      transparent_panel: !!cfg.transparent_panel,
+      opacity: opacity != null ? String(opacity) : "",
+      overlay_enabled: !!cfg.overlay,
+      overlay_color: overlay.color || "#000000",
+      overlay_opacity: overlay.opacity != null ? String(overlay.opacity) : "0.3",
+      refresh_interval: cfg.refresh_interval != null ? String(cfg.refresh_interval) : "",
+      refresh_on_update: !!cfg.refresh_on_update,
+      included_users: listToText(cfg.included_users),
+      excluded_users: listToText(cfg.excluded_users),
+      included_devices: (cfg.included_devices || []).slice(),
+      excluded_devices: (cfg.excluded_devices || []).slice(),
+      debug: !!cfg.debug,
+      display_user_agent: !!cfg.display_user_agent,
+      views: views,
+      groups: groups
+    };
+  }
+
+  // full form -> { animated_background, assignments }
+  // assignments maps dashboard view path -> group name | "none" | undefined
+  // (undefined = remove the view-level key so the view inherits root/groups)
+  function configFromForm(form) {
+    var cfg = {};
+    var assignments = {};
+
+    if (!form.enabled) cfg.enabled = false;
+
+    var default_url = linesToUrlValue(form.default_url);
+    if (default_url !== undefined) cfg.default_url = default_url;
+
+    if (String(form.entity || "").trim()) cfg.entity = String(form.entity).trim();
+
+    var state_url = rowsToStateMap(form.states);
+    if (state_url) cfg.state_url = state_url;
+
+    var opacity = parseInt(form.opacity, 10);
+    if (!isNaN(opacity) && opacity > 0 && opacity < 100) cfg.opacity = opacity;
+
+    if (form.overlay_enabled) {
+      var parsed = parseFloat(form.overlay_opacity);
+      cfg.overlay = {
+        color: String(form.overlay_color || "#000000"),
+        opacity: isNaN(parsed) ? 0.3 : Math.min(1, Math.max(0, parsed))
+      };
+    }
+
+    if (form.transparent_panel) cfg.transparent_panel = true;
+
+    var refresh_interval = parseInt(form.refresh_interval, 10);
+    if (!isNaN(refresh_interval) && refresh_interval > 0) cfg.refresh_interval = refresh_interval;
+
+    if (form.refresh_on_update) cfg.refresh_on_update = true;
+
+    var included_users = textToList(form.included_users);
+    if (included_users.length) cfg.included_users = included_users;
+
+    var excluded_users = textToList(form.excluded_users);
+    if (excluded_users.length) cfg.excluded_users = excluded_users;
+
+    if ((form.included_devices || []).length) cfg.included_devices = form.included_devices.slice();
+    if ((form.excluded_devices || []).length) cfg.excluded_devices = form.excluded_devices.slice();
+
+    if (form.debug) cfg.debug = true;
+    if (form.display_user_agent) cfg.display_user_agent = true;
+
+    var customViews = [];
+    (form.views || []).forEach(function (view) {
+      var path = String(view.path || "").trim();
+      if (!path) return;
+      if (view.mode === "custom") {
+        var config = subConfigFromForm(view.custom);
+        if (config) customViews.push({ path: path, config: config });
+      } else if (view.mode === "group") {
+        if (String(view.group || "").trim()) assignments[path] = String(view.group).trim();
+      } else if (view.mode === "none") {
+        assignments[path] = "none";
+      } else {
+        assignments[path] = undefined; // inherit: remove view-level key
+      }
+    });
+    if (customViews.length) cfg.views = customViews;
+
+    var groups = [];
+    (form.groups || []).forEach(function (group) {
+      var name = String(group.name || "").trim();
+      var config = subConfigFromForm(group.custom);
+      if (name && config) groups.push({ name: name, config: config });
+    });
+    if (groups.length) cfg.groups = groups;
+
+    return { animated_background: cfg, assignments: assignments };
+  }
+
+  // -------------------- minimal YAML serializer ------------------------
+
+  function yamlScalar(value) {
+    if (typeof value === "number" && isFinite(value)) return String(value);
+    if (typeof value === "boolean") return String(value);
+    return "'" + String(value).replace(/'/g, "''") + "'";
+  }
+
+  function yamlMapLines(obj, indent) {
+    var pad = new Array(indent + 1).join(" ");
+    return Object.keys(obj)
+      .filter(function (key) { return obj[key] !== undefined; })
+      .map(function (key) {
+        return pad + String(key) + ":" + yamlBlock(obj[key], indent);
+      })
+      .join("\n");
+  }
+
+  function yamlBlock(value, indent) {
+    if (value === null || value === undefined) return " null";
+    if (typeof value !== "object") return " " + yamlScalar(value);
+    var pad = new Array(indent + 1).join(" ");
+    if (Array.isArray(value)) {
+      if (value.length === 0) return " []";
+      return "\n" + value.map(function (item) {
+        if (item && typeof item === "object") {
+          var inner = yamlMapLines(item, indent + 2);
+          return pad + "- " + inner.slice(indent + 2);
+        }
+        return pad + "- " + yamlScalar(item);
+      }).join("\n");
+    }
+    var keys = Object.keys(value).filter(function (key) { return value[key] !== undefined; });
+    if (keys.length === 0) return " {}";
+    return "\n" + yamlMapLines(value, indent + 2);
+  }
+
+  function configToYaml(cfg) {
+    var keys = Object.keys(cfg || {}).filter(function (key) { return cfg[key] !== undefined; });
+    if (!keys.length) return "# animated_background is empty\n";
+    return yamlMapLines(cfg, 0) + "\n";
+  }
+
+  // build the YAML snippet users must add to view definitions when the
+  // editor cannot write view-level assignments itself (YAML dashboards)
+  function assignmentsToYaml(assignments) {
+    var paths = Object.keys(assignments || {}).filter(function (path) {
+      return assignments[path] !== undefined;
+    });
+    if (!paths.length) return "";
+    return "\n# Also set this on the matching view definitions in your dashboard:\n" +
+      paths.map(function (path) {
+        return "# - path: " + yamlScalar(path) + "\n#   animated_background: " + yamlScalar(assignments[path]);
+      }).join("\n") + "\n";
+  }
+
+  // -------------------- lovelace access --------------------------------
+
+  function getLovelace() {
+    try {
+      var node = document.querySelector("home-assistant");
+      node = node && node.shadowRoot;
+      node = node && node.querySelector("home-assistant-main");
+      node = node && node.shadowRoot;
+      node = node && node.querySelector("app-drawer-layout partial-panel-resolver, ha-drawer partial-panel-resolver");
+      node = (node && node.shadowRoot) || node;
+      node = node && node.querySelector && node.querySelector("ha-panel-lovelace");
+      node = node && node.shadowRoot;
+      node = node && node.querySelector("hui-root");
+      return node ? node.lovelace : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  // -------------------- the card ----------------------------------------
+
+  function defineEditor() {
+    if (customElements.get("animated-background-editor")) return;
+
+    var litBase = customElements.get("hui-view") || customElements.get("hui-masonry-view");
+    var html = litBase.html;
+    var css = litBase.css;
+    var LitElement = Object.getPrototypeOf(litBase);
+
+    class AnimatedBackgroundEditor extends LitElement {
+      static get properties() {
+        return {
+          hass: { attribute: false },
+          _tab: { state: true },
+          _form: { state: true },
+          _dirty: { state: true },
+          _status: { state: true },
+          _yamlOut: { state: true },
+          _warnings: { state: true }
+        };
+      }
+
+      static get styles() {
+        return css`
+          :host {
+            display: block;
+          }
+          .head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 8px;
+          }
+          .title {
+            font-weight: 600;
+          }
+          .tabs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-bottom: 12px;
+          }
+          .tabs button {
+            border: 1px solid var(--divider-color, #ccc);
+            background: transparent;
+            color: var(--primary-text-color, #111);
+            border-radius: 16px;
+            padding: 4px 12px;
+            cursor: pointer;
+            font-size: 13px;
+          }
+          .tabs button[active] {
+            background: var(--primary-color, #03a9f4);
+            border-color: var(--primary-color, #03a9f4);
+            color: var(--text-on-primary-color, #fff);
+          }
+          .row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+            flex-wrap: wrap;
+          }
+          .row label {
+            min-width: 170px;
+            font-size: 13px;
+          }
+          .grow {
+            flex: 1;
+            min-width: 200px;
+          }
+          input[type="text"], input[type="number"], textarea, select {
+            width: 100%;
+            box-sizing: border-box;
+            padding: 6px 8px;
+            border: 1px solid var(--divider-color, #ccc);
+            border-radius: 4px;
+            background: var(--card-background-color, #fff);
+            color: var(--primary-text-color, #111);
+            font: inherit;
+          }
+          textarea {
+            min-height: 54px;
+            resize: vertical;
+          }
+          textarea.urls {
+            font-family: var(--code-font-family, monospace);
+            font-size: 12px;
+          }
+          .check {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 13px;
+            margin: 4px 0;
+          }
+          .section {
+            border-top: 1px solid var(--divider-color, #eee);
+            margin-top: 12px;
+            padding-top: 8px;
+          }
+          .section h4 {
+            margin: 4px 0 8px;
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            opacity: 0.7;
+          }
+          .hint {
+            font-size: 12px;
+            opacity: 0.7;
+            margin: 2px 0 8px;
+          }
+          .sub {
+            border: 1px solid var(--divider-color, #ccc);
+            border-radius: 8px;
+            padding: 8px;
+            margin: 8px 0;
+          }
+          .actions {
+            display: flex;
+            gap: 8px;
+            margin-top: 12px;
+            flex-wrap: wrap;
+          }
+          button.primary, button.small {
+            cursor: pointer;
+            font: inherit;
+            border-radius: 4px;
+          }
+          button.primary {
+            background: var(--primary-color, #03a9f4);
+            color: var(--text-on-primary-color, #fff);
+            border: none;
+            padding: 8px 18px;
+          }
+          button.small {
+            background: transparent;
+            border: 1px solid var(--divider-color, #ccc);
+            color: var(--primary-text-color, #111);
+            padding: 2px 8px;
+            font-size: 12px;
+          }
+          .status {
+            font-size: 12px;
+            opacity: 0.8;
+            align-self: center;
+          }
+          .warn {
+            color: var(--warning-color, #ffa600);
+            font-size: 12px;
+            margin: 4px 0;
+          }
+          .devchips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+          }
+          .devchips label {
+            min-width: 0;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 13px;
+          }
+          pre.yaml {
+            background: var(--secondary-background-color, #f5f5f5);
+            padding: 10px;
+            border-radius: 6px;
+            overflow: auto;
+            font-size: 12px;
+            max-height: 420px;
+          }
+        `;
+      }
+
+      constructor() {
+        super();
+        this._tab = "general";
+        this._dirty = false;
+        this._status = "";
+        this._yamlOut = "";
+        this._warnings = [];
+        this._form = this._emptyForm();
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        this._reload();
+      }
+
+      setConfig() {
+        // this card is not configured through card YAML
+      }
+
+      getCardSize() {
+        return 8;
+      }
+
+      _emptyForm() {
+        return formFromConfig(null, null);
+      }
+
+      _reload() {
+        var lovelace = getLovelace();
+        var config = lovelace && lovelace.config ? lovelace.config.animated_background : null;
+        var views = lovelace && lovelace.config && lovelace.config.views ? lovelace.config.views : [];
+        this._form = formFromConfig(config, views);
+        this._dirty = false;
+        this._yamlOut = "";
+        this._warnings = [];
+      }
+
+      _update(mutator) {
+        mutator(this._form);
+        this._dirty = true;
+        this.requestUpdate();
+      }
+
+      _validate(form) {
+        var warnings = [];
+        if (form.entity && !rowsToStateMap(form.states)) {
+          warnings.push("An entity is set but no state URLs are configured, so the default URL will always be used.");
+        }
+        if (!form.entity && !splitLines(form.default_url).length) {
+          warnings.push("No default URL and no entity configured.");
+        }
+        var paths = {};
+        (form.views || []).forEach(function (view) {
+          var path = String(view.path || "").trim();
+          if (path && paths[path] && view.mode === "custom") {
+            warnings.push("More than one custom background is defined for view path '" + path + "'.");
+          }
+          paths[path] = true;
+        });
+        var names = {};
+        (form.groups || []).forEach(function (group) {
+          var name = String(group.name || "").trim();
+          if (name && names[name]) warnings.push("Duplicate group name '" + name + "'.");
+          names[name] = true;
+        });
+        return warnings;
+      }
+
+      _save() {
+        this._warnings = this._validate(this._form);
+        var lovelace = getLovelace();
+        var built = configFromForm(this._form);
+
+        if (!lovelace || typeof lovelace.saveConfig !== "function") {
+          this._yamlOut = configToYaml(built.animated_background) + assignmentsToYaml(built.assignments);
+          this._status = "Dashboard is YAML-mode: copy the generated block into your configuration file.";
+          return;
+        }
+
+        var newConfig = JSON.parse(JSON.stringify(lovelace.config));
+        if (Object.keys(built.animated_background).length > 0) {
+          newConfig.animated_background = built.animated_background;
+        } else {
+          delete newConfig.animated_background;
+        }
+        newConfig.views = (newConfig.views || []).map(function (view) {
+          var path = view.path != null ? String(view.path) : null;
+          if (path == null || !(path in built.assignments)) return view;
+          var copy = Object.assign({}, view);
+          var assignment = built.assignments[path];
+          if (assignment === undefined) {
+            delete copy.animated_background;
+          } else {
+            copy.animated_background = assignment;
+          }
+          return copy;
+        });
+
+        try {
+          lovelace.saveConfig(newConfig);
+        } catch (err) {
+          this._status = "Save failed: " + err;
+          return;
+        }
+
+        // re-read config and redraw the background immediately
+        try {
+          getVars();
+          Previous_Config = null;
+          renderBackgroundHTML();
+        } catch (err) {
+          // editor still saved successfully even if the live redraw hiccups
+        }
+
+        this._yamlOut = "";
+        this._dirty = false;
+        this._status = "Saved " + new Date().toLocaleTimeString();
+      }
+
+      _copyYaml() {
+        var text = this._yamlOut || configToYaml(configFromForm(this._form).animated_background);
+        navigator.clipboard.writeText(text).then(
+          function () { this._status = "YAML copied to clipboard"; this.requestUpdate(); }.bind(this),
+          function () { this._status = "Copy failed, select the text manually"; this.requestUpdate(); }.bind(this)
+        );
+      }
+
+      // -------------------- sub-form templates ---------------------------
+
+      _subForm(form, onEntity, onDefaultUrl, onState, onAddState, onRemoveState, onOverlay, opts) {
+        var states = form.states;
+        var currentState = "";
+        if (this.hass && form.entity && this.hass.states[form.entity]) {
+          currentState = this.hass.states[form.entity].state;
+        }
+        return html`
+          <div class="row">
+            <label>Entity</label>
+            <input class="grow" type="text" .value=${form.entity}
+              list="abe-entity-list" @change=${onEntity} placeholder="e.g. weather.home">
+          </div>
+          ${currentState ? html`<div class="hint">Current state of ${form.entity}: ${currentState}</div>` : ""}
+          ${opts && opts.hideDefaultUrl ? "" : html`
+            <div class="row">
+              <label>Default URL(s)</label>
+              <textarea class="urls grow" .value=${form.default_url} @change=${onDefaultUrl}
+                placeholder="One URL per line. Multiple lines = random choice"></textarea>
+            </div>
+          `}
+          <div class="hint">One URL per line. Multiple lines for a state = a random URL is picked each refresh.</div>
+          ${states.map(function (row, index) {
+            return html`
+              <div class="row">
+                <input style="max-width:160px" type="text" placeholder="state" .value=${row.state}
+                  @change=${function (e) { onState(index, "state", e.target.value); }}>
+                <textarea class="urls grow" placeholder="URL(s) for this state" .value=${row.urls}
+                  @change=${function (e) { onState(index, "urls", e.target.value); }}></textarea>
+                <button class="small" type="button" @click=${function () { onRemoveState(index); }}>Remove</button>
+              </div>
+            `;
+          })}
+          <div class="row">
+            <button class="small" type="button" @click=${onAddState}>Add state</button>
+          </div>
+          ${opts && opts.hideOverlay ? "" : html`
+            <div class="check">
+              <input type="checkbox" id="ovr" .checked=${form.overlay_enabled} @change=${onOverlay.toggle}>
+              <label for="ovr">Tint overlay</label>
+            </div>
+            ${form.overlay_enabled ? html`
+              <div class="row">
+                <label>Overlay color</label>
+                <input style="max-width:120px" type="text" .value=${form.overlay_color} @change=${onOverlay.color}>
+                <label style="min-width:0">Opacity (0-1)</label>
+                <input style="max-width:80px" type="number" min="0" max="1" step="0.05"
+                  .value=${form.overlay_opacity} @change=${onOverlay.opacity}>
+              </div>
+            ` : ""}
+          `}
+        `;
+      }
+
+      // -------------------- tabs ------------------------------------------
+
+      _renderGeneral() {
+        var form = this._form;
+        return html`
+          <div class="check">
+            <input type="checkbox" id="en" .checked=${form.enabled}
+              @change=${function (e) { this._update(function (f) { f.enabled = e.target.checked; }); }.bind(this)}>
+            <label for="en">Background enabled</label>
+          </div>
+          <div class="row">
+            <label>Default URL(s)</label>
+            <textarea class="urls grow" .value=${form.default_url}
+              @change=${function (e) { this._update(function (f) { f.default_url = e.target.value; }); }.bind(this)}
+              placeholder="One URL per line. Multiple lines = random choice"></textarea>
+          </div>
+          <div class="row">
+            <label>Transparent top panel</label>
+            <input type="checkbox" .checked=${form.transparent_panel}
+              @change=${function (e) { this._update(function (f) { f.transparent_panel = e.target.checked; }); }.bind(this)}>
+          </div>
+          <div class="row">
+            <label>Card opacity (1-99)</label>
+            <input style="max-width:90px" type="number" min="1" max="99" .value=${form.opacity}
+              @change=${function (e) { this._update(function (f) { f.opacity = e.target.value; }); }.bind(this)}>
+            <span class="hint">Empty = disabled. Makes cards see-through with a compatible theme. Creates a CSS stacking context (see README).</span>
+          </div>
+          <div class="check">
+            <input type="checkbox" id="ov" .checked=${form.overlay_enabled}
+              @change=${function (e) { this._update(function (f) { f.overlay_enabled = e.target.checked; }); }.bind(this)}>
+            <label for="ov">Tint overlay over the background</label>
+          </div>
+          ${form.overlay_enabled ? html`
+            <div class="row">
+              <label>Overlay color</label>
+              <input style="max-width:120px" type="text" .value=${form.overlay_color}
+                @change=${function (e) { this._update(function (f) { f.overlay_color = e.target.value; }); }.bind(this)}>
+              <label style="min-width:0">Opacity (0-1)</label>
+              <input style="max-width:80px" type="number" min="0" max="1" step="0.05" .value=${form.overlay_opacity}
+                @change=${function (e) { this._update(function (f) { f.overlay_opacity = e.target.value; }); }.bind(this)}>
+            </div>
+          ` : ""}
+          <div class="row">
+            <label>Refresh interval (minutes)</label>
+            <input style="max-width:90px" type="number" min="1" .value=${form.refresh_interval}
+              @change=${function (e) { this._update(function (f) { f.refresh_interval = e.target.value; }); }.bind(this)}>
+            <span class="hint">Empty = never. Re-picks from the current URL list.</span>
+          </div>
+          <div class="check">
+            <input type="checkbox" id="rou" .checked=${form.refresh_on_update}
+              @change=${function (e) { this._update(function (f) { f.refresh_on_update = e.target.checked; }); }.bind(this)}>
+            <label for="rou">Refresh when the entity updates, even if the state is unchanged</label>
+          </div>
+        `;
+      }
+
+      _renderStates() {
+        var form = this._form;
+        var self = this;
+        return html`
+          ${this._subForm(
+            { entity: form.entity, default_url: "", states: form.states, overlay_enabled: false,
+              overlay_color: "#000000", overlay_opacity: "0.3" },
+            function (e) { self._update(function (f) { f.entity = e.target.value; }); },
+            function () {},
+            function (index, field, value) {
+              self._update(function (f) { f.states[index][field] = value; });
+            },
+            function () {
+              self._update(function (f) { f.states.push({ state: "", urls: "" }); });
+            },
+            function (index) {
+              self._update(function (f) { f.states.splice(index, 1); });
+            },
+            {
+              toggle: function () {},
+              color: function () {},
+              opacity: function () {}
+            },
+            { hideDefaultUrl: true, hideOverlay: true }
+          )}
+          <div class="hint">Maps states of the entity above to background URLs. States without an entry fall back to the default URL. Set a state's URL to <b>none</b> to disable the background for that state.</div>
+        `;
+      }
+
+      _renderViews() {
+        var self = this;
+        var form = this._form;
+        var groupNames = (form.groups || []).map(function (g) { return g.name; }).filter(Boolean);
+        return html`
+          <div class="hint">Per-view overrides. "Inherit" uses the root config (and any group assigned to the view). Group/None assignments are written onto the dashboard view definitions on save.</div>
+          ${(form.views || []).map(function (view, index) {
+            var isCustom = view.mode === "custom";
+            return html`
+              <div class="sub">
+                <div class="row">
+                  <b>${view.title || view.path}</b>
+                  <span class="hint">${view.path}${view.orphan ? " (stale entry)" : ""}</span>
+                </div>
+                <div class="row">
+                  <label>Background</label>
+                  <select .value=${view.mode}
+                    @change=${function (e) {
+                      self._update(function (f) { f.views[index].mode = e.target.value; });
+                    }}>
+                    <option value="inherit">Inherit root config</option>
+                    <option value="group">Use a group</option>
+                    <option value="none">Disabled ('none')</option>
+                    <option value="custom">Custom config</option>
+                  </select>
+                  ${view.mode === "group" ? html`
+                    <select .value=${view.group}
+                      @change=${function (e) {
+                        self._update(function (f) { f.views[index].group = e.target.value; });
+                      }}>
+                      <option value="">Choose group...</option>
+                      ${groupNames.map(function (name) {
+                        return html`<option value=${name} ?selected=${name === view.group}>${name}</option>`;
+                      })}
+                    </select>
+                  ` : ""}
+                </div>
+                ${isCustom ? html`
+                  <div class="sub">
+                    ${self._subForm(
+                      view.custom,
+                      function (e) { self._update(function (f) { f.views[index].custom.entity = e.target.value; }); },
+                      function (e) { self._update(function (f) { f.views[index].custom.default_url = e.target.value; }); },
+                      function (si, field, value) {
+                        self._update(function (f) { f.views[index].custom.states[si][field] = value; });
+                      },
+                      function () {
+                        self._update(function (f) { f.views[index].custom.states.push({ state: "", urls: "" }); });
+                      },
+                      function (si) {
+                        self._update(function (f) { f.views[index].custom.states.splice(si, 1); });
+                      },
+                      {
+                        toggle: function (e) { self._update(function (f) { f.views[index].custom.overlay_enabled = e.target.checked; }); },
+                        color: function (e) { self._update(function (f) { f.views[index].custom.overlay_color = e.target.value; }); },
+                        opacity: function (e) { self._update(function (f) { f.views[index].custom.overlay_opacity = e.target.value; }); }
+                      }
+                    )}
+                  </div>
+                ` : ""}
+              </div>
+            `;
+          })}
+          ${(form.views || []).length === 0 ? html`<div class="hint">This dashboard has no views yet.</div>` : ""}
+        `;
+      }
+
+      _renderGroups() {
+        var self = this;
+        var form = this._form;
+        return html`
+          <div class="hint">Named reusable configurations. Assign them to views in the Views tab, or set <b>animated_background: &lt;group name&gt;</b> on a view definition.</div>
+          ${(form.groups || []).map(function (group, index) {
+            return html`
+              <div class="sub">
+                <div class="row">
+                  <label>Group name</label>
+                  <input class="grow" type="text" .value=${group.name}
+                    @change=${function (e) {
+                      self._update(function (f) { f.groups[index].name = e.target.value; });
+                    }}>
+                  <button class="small" type="button"
+                    @click=${function () { self._update(function (f) { f.groups.splice(index, 1); }); }}>Remove group</button>
+                </div>
+                ${self._subForm(
+                  group.custom,
+                  function (e) { self._update(function (f) { f.groups[index].custom.entity = e.target.value; }); },
+                  function (e) { self._update(function (f) { f.groups[index].custom.default_url = e.target.value; }); },
+                  function (si, field, value) {
+                    self._update(function (f) { f.groups[index].custom.states[si][field] = value; });
+                  },
+                  function () {
+                    self._update(function (f) { f.groups[index].custom.states.push({ state: "", urls: "" }); });
+                  },
+                  function (si) {
+                    self._update(function (f) { f.groups[index].custom.states.splice(si, 1); });
+                  },
+                  {
+                    toggle: function (e) { self._update(function (f) { f.groups[index].custom.overlay_enabled = e.target.checked; }); },
+                    color: function (e) { self._update(function (f) { f.groups[index].custom.overlay_color = e.target.value; }); },
+                    opacity: function (e) { self._update(function (f) { f.groups[index].custom.overlay_opacity = e.target.value; }); }
+                  }
+                )}
+              </div>
+            `;
+          })}
+          <div class="row">
+            <button class="small" type="button"
+              @click=${function () {
+                self._update(function (f) {
+                  f.groups.push({ name: "", custom: subFormFromConfig(null) });
+                });
+              }}>Add group</button>
+          </div>
+        `;
+      }
+
+      _renderAccess() {
+        var self = this;
+        var form = this._form;
+        var deviceRow = function (field) {
+          return html`
+            <div class="devchips">
+              ${KNOWN_DEVICES.map(function (device) {
+                var checked = (form[field] || []).indexOf(device) !== -1;
+                return html`
+                  <label>
+                    <input type="checkbox" .checked=${checked}
+                      @change=${function (e) {
+                        self._update(function (f) {
+                          var list = f[field];
+                          var at = list.indexOf(device);
+                          if (e.target.checked && at === -1) list.push(device);
+                          if (!e.target.checked && at !== -1) list.splice(at, 1);
+                        });
+                      }}>
+                    ${device}
+                  </label>
+                `;
+              })}
+            </div>
+          `;
+        };
+        return html`
+          <div class="section">
+            <h4>Included users (empty = everyone)</h4>
+            <textarea class="grow" .value=${form.included_users}
+              @change=${function (e) { self._update(function (f) { f.included_users = e.target.value; }); }}></textarea>
+            <h4>Excluded users</h4>
+            <textarea class="grow" .value=${form.excluded_users}
+              @change=${function (e) { self._update(function (f) { f.excluded_users = e.target.value; }); }}></textarea>
+            <div class="hint">Comma or newline separated Home Assistant usernames.</div>
+          </div>
+          <div class="section">
+            <h4>Included devices (empty = all)</h4>
+            ${deviceRow("included_devices")}
+            <h4>Excluded devices</h4>
+            ${deviceRow("excluded_devices")}
+            <div class="hint">Device types are matched against the browser user agent. Use debug + "show user agent" on the Advanced tab to find the right value.</div>
+          </div>
+        `;
+      }
+
+      _renderAdvanced() {
+        var self = this;
+        var form = this._form;
+        return html`
+          <div class="check">
+            <input type="checkbox" id="dbg" .checked=${form.debug}
+              @change=${function (e) { self._update(function (f) { f.debug = e.target.checked; }); }}>
+            <label for="dbg">Debug logging (browser console)</label>
+          </div>
+          <div class="check">
+            <input type="checkbox" id="ua" .checked=${form.display_user_agent}
+              @change=${function (e) { self._update(function (f) { f.display_user_agent = e.target.checked; }); }}>
+            <label for="ua">Show my user agent on reload (for device lists)</label>
+          </div>
+        `;
+      }
+
+      render() {
+        var self = this;
+        var tabs = [
+          ["general", "General"],
+          ["states", "Entity & States"],
+          ["views", "Views"],
+          ["groups", "Groups"],
+          ["access", "Access"],
+          ["advanced", "Advanced"]
+        ];
+        var body;
+        if (this._tab === "general") body = this._renderGeneral();
+        else if (this._tab === "states") body = this._renderStates();
+        else if (this._tab === "views") body = this._renderViews();
+        else if (this._tab === "groups") body = this._renderGroups();
+        else if (this._tab === "access") body = this._renderAccess();
+        else body = this._renderAdvanced();
+
+        var entityList = this.hass ? Object.keys(this.hass.states) : [];
+
+        return html`
+          <ha-card>
+            <div style="padding: 12px 16px 16px">
+              <div class="head">
+                <span class="title">Animated Background</span>
+                <span class="status">${this._status}</span>
+              </div>
+              <div class="tabs">
+                ${tabs.map(function (tab) {
+                  return html`
+                    <button type="button" ?active=${self._tab === tab[0]}
+                      @click=${function () { self._tab = tab[0]; self.requestUpdate(); }}>${tab[1]}</button>
+                  `;
+                })}
+              </div>
+              ${this._warnings.map(function (warning) {
+                return html`<div class="warn">${warning}</div>`;
+              })}
+              ${body}
+              ${this._yamlOut ? html`
+                <div class="section">
+                  <h4>Generated YAML</h4>
+                  <pre class="yaml" id="abe-yaml">${this._yamlOut}</pre>
+                  <div class="row">
+                    <button class="small" type="button" @click=${function () { self._copyYaml(); }}>Copy YAML</button>
+                  </div>
+                </div>
+              ` : ""}
+              <div class="actions">
+                <button class="primary" type="button" ?disabled=${!this._dirty}
+                  @click=${function () { self._save(); }}>Save</button>
+                <button class="small" type="button" @click=${function () { self._reload(); }}>Reload config</button>
+                <button class="small" type="button" @click=${function () { self._copyYaml(); }}>Copy YAML</button>
+              </div>
+            </div>
+          </ha-card>
+          <datalist id="abe-entity-list">
+            ${entityList.map(function (entityId) {
+              return html`<option value=${entityId}></option>`;
+            })}
+          </datalist>
+        `;
+      }
+    }
+
+    customElements.define("animated-background-editor", AnimatedBackgroundEditor);
+
+    window.customCards = window.customCards || [];
+    window.customCards.push({
+      type: "animated-background-editor",
+      name: "Animated Background Editor",
+      description: "Visual editor for the dashboard's animated_background configuration",
+      preview: false
+    });
+
+    STATUS_MESSAGE("Editor card registered");
+  }
+
+  // wait for HA's Lit classes to exist before defining the card
+  var attempts = 0;
+  var wait_timer = setInterval(function () {
+    attempts++;
+    if (customElements.get("hui-view") || customElements.get("hui-masonry-view")) {
+      clearInterval(wait_timer);
+      try {
+        defineEditor();
+      } catch (err) {
+        console.error("Animated Background: failed to register editor card", err);
+      }
+    } else if (attempts > 240) {
+      clearInterval(wait_timer);
+      console.warn("Animated Background: editor card not registered, HA frontend elements never appeared");
+    }
+  }, 500);
+
+  // exposed for testing
+  window.__animatedBackgroundEditor = {
+    splitLines: splitLines,
+    linesToUrlValue: linesToUrlValue,
+    urlValueToLines: urlValueToLines,
+    textToList: textToList,
+    subFormFromConfig: subFormFromConfig,
+    subConfigFromForm: subConfigFromForm,
+    formFromConfig: formFromConfig,
+    configFromForm: configFromForm,
+    configToYaml: configToYaml
+  };
+})();

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -17,6 +17,7 @@ var View_Loaded = false;
 var Meme_Remover = null;
 var Meme_Count = 0;
 var Refresh_Timer = null;
+var Refresh_Interval_Value = null;
 var Wait_Interval = null;
 var Opacity = 99;
 
@@ -450,7 +451,13 @@ function renderBackgroundHTML() {
   var refresh_interval = current_config.refresh_interval !== undefined
     ? current_config.refresh_interval
     : (Animated_Config ? Animated_Config.refresh_interval : undefined);
+  if (refresh_interval && refresh_interval != Refresh_Interval_Value) {
+    // interval edited since the timer was created - restart so the change
+    // applies without waiting for a page reload
+    clearRefreshTimer();
+  }
   if (refresh_interval && !Refresh_Timer) {
+    Refresh_Interval_Value = refresh_interval;
     Refresh_Timer = setInterval(function() {
       Previous_State = null;
       Previous_Url = null;
@@ -540,27 +547,25 @@ function renderBackgroundHTML() {
     ${overlay_html}
     </body>
     </html>`;
-    if (!bg) {
-      if (!current_config.entity) {
-        STATUS_MESSAGE("Applying default background", true);
-      }
-      var style = document.createElement("style");
-      style.id = "animated-bg-style";
-      style.innerHTML = `
+    // Style is (re)applied on every render, not just when the iframe is
+    // first created, so per-view opacity changes take effect on navigation
+    // without a page reload. Replace-in-place keeps this idempotent.
+    var style = Root.shadowRoot.getElementById('animated-bg-style');
+    var style_rules = `
       .bg-video{
-          min-width: 100vw; 
-          min-height: 100vh;    
+          min-width: 100vw;
+          min-height: 100vh;
       }
-      
+
       #view {
           background: none;
         }
-      
+
       .bg-wrap{
           position: fixed;
           left: 0;
           top: 0;
-          min-width: 100vw; 
+          min-width: 100vw;
           min-height: 100vh;
           z-index: -12;
           pointer-events: none;
@@ -575,16 +580,32 @@ function renderBackgroundHTML() {
       }
       `;
 
-      // Only apply opacity if configured - note this creates a CSS stacking
-      // context which may cause overlays (e.g. Bubble Card) to appear behind
-      // the background. Remove opacity: from your config if this affects you.
-      if (Opacity < 99) {
-        style.innerHTML += `
+    // Only apply opacity if configured - note this creates a CSS stacking
+    // context which may cause overlays (e.g. Bubble Card) to appear behind
+    // the background. Remove opacity: from your config if this affects you.
+    if (Opacity < 99) {
+      // Computed numerically: concatenating after "0." turned single-digit
+      // values (5) into ten times the intended opacity (0.5).
+      var alpha = Math.min(99, Math.max(1, parseInt(Opacity, 10))) / 100;
+      style_rules += `
       hui-masonry-view,
       hui-sections-view,
       hui-panel-view {
-          opacity: 0.` + Opacity + `;
+          opacity: ${alpha};
       }`;
+    }
+    if (!style) {
+      style = document.createElement("style");
+      style.id = "animated-bg-style";
+      style.innerHTML = style_rules;
+      Root.shadowRoot.appendChild(style);
+    } else if (style.innerHTML != style_rules) {
+      style.innerHTML = style_rules;
+    }
+
+    if (!bg) {
+      if (!current_config.entity) {
+        STATUS_MESSAGE("Applying default background", true);
       }
 
 // transparent for top Pannel
@@ -592,15 +613,14 @@ function renderBackgroundHTML() {
       div.id = "background-video";
       div.className = "bg-wrap";
       div.innerHTML = `
-       <iframe id="background-iframe" class="bg-video" frameborder="0" style="pointer-events:none;" srcdoc="${source_doc}"/> 
-      
+       <iframe id="background-iframe" class="bg-video" frameborder="0" style="pointer-events:none;" srcdoc="${source_doc}"/>
+
       `;
-    
-      Root.shadowRoot.appendChild(style);
+
       Root.shadowRoot.appendChild(div);
-      
+
       View.setAttribute ("style","background:none;");
-      
+
       Previous_Url = state_url;
     }
     else {
@@ -737,6 +757,7 @@ function clearMemes() {
 function clearRefreshTimer() {
   clearInterval(Refresh_Timer);
   Refresh_Timer = null;
+  Refresh_Interval_Value = null;
 }
 
 function setDebugMode() {

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -864,6 +864,7 @@ function restart() {
 
 run();
 
+
 // ======================================================================
 // Visual Configuration Editor
 //
@@ -873,6 +874,16 @@ run();
 // saves it back through hui-root's lovelace.saveConfig(). On YAML-mode
 // dashboards (where saveConfig is unavailable) it instead shows the
 // generated YAML block to copy into your configuration file.
+//
+// Implementation rules (see docs/EDITOR_IMPLEMENTATION_GUIDE.md):
+// - No Lit. Plain DOM plus HA's globally-registered custom elements,
+//   guarded with customElements.get() so a rename degrades, not breaks.
+// - A registration failure must never stop the background from
+//   rendering (defineEditor() is wrapped in try/catch below).
+// - The editor only touches the root `animated_background:` key and the
+//   `animated_background:` key on view definitions. Saves are merges
+//   over the original parsed config, so hand-written keys the editor
+//   does not know about survive a round-trip.
 // ======================================================================
 (function () {
   "use strict";
@@ -941,7 +952,23 @@ run();
     return Object.keys(map).length > 0 ? map : undefined;
   }
 
-  // sub-config (group/view config) -> editable sub-form
+  function parseOpacity(text) {
+    var parsed = parseFloat(text);
+    return isNaN(parsed) ? null : Math.min(1, Math.max(0, parsed));
+  }
+
+  // set key to value, or delete the key when value is undefined — a save
+  // must never write an empty/default value into the config
+  function setOrRemove(obj, key, value) {
+    if (value === undefined) delete obj[key];
+    else obj[key] = value;
+  }
+
+  // -------------------- sub-form <-> sub-config ------------------------
+
+  // Sub-configs (groups and per-view config blocks) support the same
+  // option set as the root, minus views, groups, debug and
+  // display_user_agent (meaningfully root-only).
   function subFormFromConfig(cfg) {
     cfg = cfg || {};
     var overlay = cfg.overlay || {};
@@ -949,29 +976,75 @@ run();
       entity: cfg.entity || "",
       default_url: urlValueToLines(cfg.default_url),
       states: stateMapToRows(cfg.state_url),
+      background: cfg.background != null ? String(cfg.background) : "",
+      transparent_panel: !!cfg.transparent_panel,
+      opacity: cfg.opacity != null ? String(cfg.opacity) : "",
       overlay_enabled: !!cfg.overlay,
       overlay_color: overlay.color || "#000000",
-      overlay_opacity: overlay.opacity != null ? String(overlay.opacity) : "0.3"
+      overlay_opacity: overlay.opacity != null ? String(overlay.opacity) : "0.3",
+      refresh_interval: cfg.refresh_interval != null ? String(cfg.refresh_interval) : "",
+      refresh_on_update: !!cfg.refresh_on_update,
+      included_users: listToText(cfg.included_users),
+      excluded_users: listToText(cfg.excluded_users),
+      included_devices: (cfg.included_devices || []).slice(),
+      excluded_devices: (cfg.excluded_devices || []).slice()
     };
   }
 
-  // editable sub-form -> sub-config, or null when the form is empty
-  function subConfigFromForm(sf) {
+  // editable sub-form -> sub-config. Merge over the original parsed
+  // config so hand-written keys the editor does not model survive a save
+  // (guide §3.3). Returns null when the result would be empty.
+  function subConfigFromForm(sf, original) {
     if (!sf) return null;
-    var cfg = {};
-    if (String(sf.entity || "").trim()) cfg.entity = String(sf.entity).trim();
-    var default_url = linesToUrlValue(sf.default_url);
-    if (default_url !== undefined) cfg.default_url = default_url;
-    var state_url = rowsToStateMap(sf.states);
-    if (state_url) cfg.state_url = state_url;
+    var cfg = original ? JSON.parse(JSON.stringify(original)) : {};
+
+    setOrRemove(cfg, "entity", String(sf.entity || "").trim() || undefined);
+    setOrRemove(cfg, "default_url", linesToUrlValue(sf.default_url));
+    setOrRemove(cfg, "state_url", rowsToStateMap(sf.states));
+    setOrRemove(cfg, "background", String(sf.background || "").trim() || undefined);
+
+    var opacity = parseInt(sf.opacity, 10);
+    setOrRemove(cfg, "opacity",
+      !isNaN(opacity) && opacity > 0 && opacity < 100 ? opacity : undefined);
+
     if (sf.overlay_enabled) {
-      var parsed = parseFloat(sf.overlay_opacity);
-      cfg.overlay = {
-        color: String(sf.overlay_color || "#000000"),
-        opacity: isNaN(parsed) ? 0.3 : Math.min(1, Math.max(0, parsed))
-      };
+      var overlay = cfg.overlay && typeof cfg.overlay === "object" && !Array.isArray(cfg.overlay)
+        ? cfg.overlay : {};
+      overlay.color = String(sf.overlay_color || "#000000");
+      var parsed = parseOpacity(sf.overlay_opacity);
+      overlay.opacity = parsed != null ? parsed : 0.3;
+      cfg.overlay = overlay;
+    } else {
+      delete cfg.overlay;
     }
+
+    if (sf.transparent_panel) cfg.transparent_panel = true;
+    else delete cfg.transparent_panel;
+
+    var refresh_interval = parseInt(sf.refresh_interval, 10);
+    setOrRemove(cfg, "refresh_interval",
+      !isNaN(refresh_interval) && refresh_interval > 0 ? refresh_interval : undefined);
+
+    if (sf.refresh_on_update) cfg.refresh_on_update = true;
+    else delete cfg.refresh_on_update;
+
+    var included_users = textToList(sf.included_users);
+    setOrRemove(cfg, "included_users", included_users.length ? included_users : undefined);
+    var excluded_users = textToList(sf.excluded_users);
+    setOrRemove(cfg, "excluded_users", excluded_users.length ? excluded_users : undefined);
+    setOrRemove(cfg, "included_devices", (sf.included_devices || []).length ? sf.included_devices.slice() : undefined);
+    setOrRemove(cfg, "excluded_devices", (sf.excluded_devices || []).length ? sf.excluded_devices.slice() : undefined);
+
     return Object.keys(cfg).length > 0 ? cfg : null;
+  }
+
+  // -------------------- root form <-> root config ----------------------
+
+  // View identity: match on `path` when the view has one, on array
+  // position otherwise — the SAME rule at read and write time (guide
+  // §2.5), so group/none assignments work on path-less views.
+  function viewIdentity(view, index) {
+    return view && view.path != null ? String(view.path) : String(index);
   }
 
   // root config + lovelace views -> full editable form
@@ -979,25 +1052,31 @@ run();
     cfg = cfg || {};
     var overlay = cfg.overlay || {};
 
-    var customByPath = {};
+    // every root views: entry, keyed by path — both custom configs and
+    // legacy assignment entries
+    var entriesByPath = {};
     (cfg.views || []).forEach(function (entry) {
-      if (entry && entry.path != null && entry.config) {
-        customByPath[String(entry.path)] = entry.config;
-      }
+      if (entry && entry.path != null) entriesByPath[String(entry.path)] = entry;
     });
 
     var seen = {};
     var views = [];
     (lovelaceViews || []).forEach(function (view, index) {
-      var path = view.path != null ? String(view.path) : String(index);
-      seen[path] = true;
+      var identity = viewIdentity(view, index);
+      seen[identity] = true;
+      var entry = entriesByPath[identity];
       var assignment = view.animated_background;
       var mode = "inherit";
       var group = "";
       var custom = null;
-      if (customByPath[path]) {
+      if (entry && entry.config) {
         mode = "custom";
-        custom = subFormFromConfig(customByPath[path]);
+        custom = subFormFromConfig(entry.config);
+      } else if (entry && entry.animated_background === "none") {
+        mode = "none";
+      } else if (entry && typeof entry.animated_background === "string" && entry.animated_background) {
+        mode = "group";
+        group = entry.animated_background;
       } else if (assignment === "none") {
         mode = "none";
       } else if (typeof assignment === "string" && assignment) {
@@ -1005,7 +1084,7 @@ run();
         group = assignment;
       }
       views.push({
-        path: path,
+        path: identity,
         title: view.title || "",
         mode: mode,
         group: group,
@@ -1013,18 +1092,32 @@ run();
         custom: custom || subFormFromConfig(null)
       });
     });
-    // root `views:` entries that no longer match a dashboard view (stale)
-    Object.keys(customByPath).forEach(function (path) {
-      if (!seen[path]) {
-        views.push({
-          path: path,
-          title: "(view not found in dashboard)",
-          mode: "custom",
-          group: "",
-          orphan: true,
-          custom: subFormFromConfig(customByPath[path])
-        });
+    // root `views:` entries that no longer match a dashboard view. Shown,
+    // flagged and removable — never silently dropped (guide §5).
+    Object.keys(entriesByPath).forEach(function (path) {
+      if (seen[path]) return;
+      var entry = entriesByPath[path];
+      var mode = "custom";
+      var group = "";
+      var custom = entry.config ? subFormFromConfig(entry.config) : null;
+      if (!custom) {
+        if (entry.animated_background === "none") {
+          mode = "none";
+        } else if (typeof entry.animated_background === "string" && entry.animated_background) {
+          mode = "group";
+          group = entry.animated_background;
+        } else {
+          custom = subFormFromConfig(null);
+        }
       }
+      views.push({
+        path: path,
+        title: "(view not found in dashboard)",
+        mode: mode,
+        group: group,
+        orphan: true,
+        custom: custom || subFormFromConfig(null)
+      });
     });
 
     var groups = (cfg.groups || []).map(function (group) {
@@ -1038,6 +1131,7 @@ run();
     return {
       enabled: cfg.enabled !== false,
       default_url: urlValueToLines(cfg.default_url),
+      background: cfg.background != null ? String(cfg.background) : "",
       entity: cfg.entity || "",
       states: stateMapToRows(cfg.state_url),
       transparent_panel: !!cfg.transparent_panel,
@@ -1058,74 +1152,109 @@ run();
     };
   }
 
-  // full form -> { animated_background, assignments }
-  // assignments maps dashboard view path -> group name | "none" | undefined
-  // (undefined = remove the view-level key so the view inherits root/groups)
-  function configFromForm(form) {
-    var cfg = {};
+  // full form -> { animated_background, assignments }. Merge over the
+  // original parsed root config (guide §3.3). assignments maps dashboard
+  // view identity -> group name | "none" | undefined (undefined = remove
+  // the view-level key so the view inherits root/groups).
+  function configFromForm(form, original) {
+    var cfg = original ? JSON.parse(JSON.stringify(original)) : {};
     var assignments = {};
 
-    if (!form.enabled) cfg.enabled = false;
+    // original custom view configs, for per-view merges
+    var originalByPath = {};
+    var originalAssignmentEntries = {};
+    ((original || {}).views || []).forEach(function (entry) {
+      if (!entry || entry.path == null) return;
+      var path = String(entry.path);
+      if (entry.config) originalByPath[path] = entry.config;
+      else originalAssignmentEntries[path] = entry;
+    });
 
-    var default_url = linesToUrlValue(form.default_url);
-    if (default_url !== undefined) cfg.default_url = default_url;
+    if (form.enabled) delete cfg.enabled;
+    else cfg.enabled = false;
 
-    if (String(form.entity || "").trim()) cfg.entity = String(form.entity).trim();
-
-    var state_url = rowsToStateMap(form.states);
-    if (state_url) cfg.state_url = state_url;
+    setOrRemove(cfg, "default_url", linesToUrlValue(form.default_url));
+    setOrRemove(cfg, "entity", String(form.entity || "").trim() || undefined);
+    setOrRemove(cfg, "state_url", rowsToStateMap(form.states));
+    setOrRemove(cfg, "background", String(form.background || "").trim() || undefined);
 
     var opacity = parseInt(form.opacity, 10);
-    if (!isNaN(opacity) && opacity > 0 && opacity < 100) cfg.opacity = opacity;
+    setOrRemove(cfg, "opacity",
+      !isNaN(opacity) && opacity > 0 && opacity < 100 ? opacity : undefined);
 
     if (form.overlay_enabled) {
-      var parsed = parseFloat(form.overlay_opacity);
-      cfg.overlay = {
-        color: String(form.overlay_color || "#000000"),
-        opacity: isNaN(parsed) ? 0.3 : Math.min(1, Math.max(0, parsed))
-      };
+      var overlay = cfg.overlay && typeof cfg.overlay === "object" && !Array.isArray(cfg.overlay)
+        ? cfg.overlay : {};
+      overlay.color = String(form.overlay_color || "#000000");
+      var parsed = parseOpacity(form.overlay_opacity);
+      overlay.opacity = parsed != null ? parsed : 0.3;
+      cfg.overlay = overlay;
+    } else {
+      delete cfg.overlay;
     }
 
     if (form.transparent_panel) cfg.transparent_panel = true;
+    else delete cfg.transparent_panel;
 
     var refresh_interval = parseInt(form.refresh_interval, 10);
-    if (!isNaN(refresh_interval) && refresh_interval > 0) cfg.refresh_interval = refresh_interval;
+    setOrRemove(cfg, "refresh_interval",
+      !isNaN(refresh_interval) && refresh_interval > 0 ? refresh_interval : undefined);
 
     if (form.refresh_on_update) cfg.refresh_on_update = true;
+    else delete cfg.refresh_on_update;
 
     var included_users = textToList(form.included_users);
-    if (included_users.length) cfg.included_users = included_users;
-
+    setOrRemove(cfg, "included_users", included_users.length ? included_users : undefined);
     var excluded_users = textToList(form.excluded_users);
-    if (excluded_users.length) cfg.excluded_users = excluded_users;
-
-    if ((form.included_devices || []).length) cfg.included_devices = form.included_devices.slice();
-    if ((form.excluded_devices || []).length) cfg.excluded_devices = form.excluded_devices.slice();
+    setOrRemove(cfg, "excluded_users", excluded_users.length ? excluded_users : undefined);
+    setOrRemove(cfg, "included_devices", (form.included_devices || []).length ? form.included_devices.slice() : undefined);
+    setOrRemove(cfg, "excluded_devices", (form.excluded_devices || []).length ? form.excluded_devices.slice() : undefined);
 
     if (form.debug) cfg.debug = true;
+    else delete cfg.debug;
     if (form.display_user_agent) cfg.display_user_agent = true;
+    else delete cfg.display_user_agent;
 
+    // views: custom configs rebuild the root views: list; group/none go
+    // onto the dashboard view definitions — except stale paths, which
+    // have no dashboard view to receive them and are preserved in place
     var customViews = [];
+    var staleAssignmentEntries = [];
     (form.views || []).forEach(function (view) {
       var path = String(view.path || "").trim();
       if (!path) return;
       if (view.mode === "custom") {
-        var config = subConfigFromForm(view.custom);
+        var config = subConfigFromForm(view.custom, originalByPath[path]);
         if (config) customViews.push({ path: path, config: config });
       } else if (view.mode === "group") {
-        if (String(view.group || "").trim()) assignments[path] = String(view.group).trim();
+        var group = String(view.group || "").trim();
+        if (group) {
+          if (view.orphan) {
+            staleAssignmentEntries.push({ path: path, animated_background: group });
+          } else {
+            assignments[path] = group;
+          }
+        }
       } else if (view.mode === "none") {
-        assignments[path] = "none";
+        if (view.orphan) staleAssignmentEntries.push({ path: path, animated_background: "none" });
+        else assignments[path] = "none";
       } else {
-        assignments[path] = undefined; // inherit: remove view-level key
+        assignments[path] = undefined; // inherit: remove the view-level key
       }
     });
-    if (customViews.length) cfg.views = customViews;
+    if (customViews.length || staleAssignmentEntries.length) {
+      cfg.views = customViews.concat(staleAssignmentEntries);
+    } else {
+      delete cfg.views;
+    }
 
     var groups = [];
     (form.groups || []).forEach(function (group) {
       var name = String(group.name || "").trim();
-      var config = subConfigFromForm(group.custom);
+      var originalGroup = ((original || {}).groups || []).filter(function (g) {
+        return g && g.name === name;
+      })[0];
+      var config = subConfigFromForm(group.custom, originalGroup && originalGroup.config);
       if (name && config) groups.push({ name: name, config: config });
     });
     if (groups.length) cfg.groups = groups;
@@ -1170,10 +1299,13 @@ run();
     return "\n" + yamlMapLines(value, indent + 2);
   }
 
+  // Serializes the complete `animated_background:` block INCLUDING the
+  // root key, so the output pastes into configuration.yaml verbatim
+  // (guide §2.3).
   function configToYaml(cfg) {
     var keys = Object.keys(cfg || {}).filter(function (key) { return cfg[key] !== undefined; });
     if (!keys.length) return "# animated_background is empty\n";
-    return yamlMapLines(cfg, 0) + "\n";
+    return yamlMapLines({ animated_background: cfg }, 0) + "\n";
   }
 
   // build the YAML snippet users must add to view definitions when the
@@ -1189,7 +1321,7 @@ run();
       }).join("\n") + "\n";
   }
 
-  // -------------------- lovelace access --------------------------------
+  // -------------------- lovelace / hass access -------------------------
 
   function getLovelace() {
     try {
@@ -1208,196 +1340,137 @@ run();
     }
   }
 
+  function getHass() {
+    try {
+      var ha = document.querySelector("home-assistant");
+      return ha && ha.hass ? ha.hass : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  // clipboard with a fallback for non-secure origins (plain-HTTP LAN
+  // installs have no navigator.clipboard — guide §2.6)
+  function copyText(text, done) {
+    var fallback = function () {
+      try {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        var ok = document.execCommand("copy");
+        ta.remove();
+        return ok;
+      } catch (err) {
+        return false;
+      }
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(
+        function () { done(true); },
+        function () { done(fallback()); });
+    } else {
+      done(fallback());
+    }
+  }
+
+  // -------------------- DOM builders ------------------------------------
+
+  // property-backed element factory: value/checked/disabled go through
+  // properties (setAttribute("checked", "") semantics differ), listeners
+  // via on*, everything else via attributes
+  function h(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        var v = attrs[k];
+        if (v === null || v === undefined || v === false) return;
+        if (k === "class") node.className = v;
+        else if (k === "text") node.textContent = v;
+        else if (k === "value" || k === "checked" || k === "disabled" ||
+                 k === "selected" || k === "min" || k === "max" || k === "step" ||
+                 k === "type" || k === "placeholder" || k === "for") {
+          if (k in node) node[k] = v;
+          else node.setAttribute(k, v === true ? "" : v);
+        } else if (k.slice(0, 2) === "on" && typeof v === "function") {
+          node.addEventListener(k.slice(2), v);
+        } else {
+          node.setAttribute(k, v === true ? "" : v);
+        }
+      });
+    }
+    (children || []).forEach(function (c) {
+      if (c === null || c === undefined) return;
+      node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    });
+    return node;
+  }
+
+  function styleNode() {
+    var style = document.createElement("style");
+    style.textContent = [
+      ":host { display: block; }",
+      ".head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; }",
+      ".title { font-weight: 600; }",
+      ".tabs { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 12px; }",
+      ".tabs button { border: 1px solid var(--divider-color, #ccc); background: transparent; color: var(--primary-text-color, #111); border-radius: 16px; padding: 4px 12px; cursor: pointer; font-size: 13px; }",
+      ".tabs button[active] { background: var(--primary-color, #03a9f4); border-color: var(--primary-color, #03a9f4); color: var(--text-on-primary-color, #fff); }",
+      ".row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }",
+      ".row > label:first-child { min-width: 170px; font-size: 13px; }",
+      ".grow { flex: 1; min-width: 200px; }",
+      "input[type=text], input[type=number], textarea, select { width: 100%; box-sizing: border-box; padding: 6px 8px; border: 1px solid var(--divider-color, #ccc); border-radius: 4px; background: var(--card-background-color, #fff); color: var(--primary-text-color, #111); font: inherit; }",
+      "ha-textfield { width: 100%; }",
+      "ha-textfield.grow { flex: 1; min-width: 200px; }",
+      "textarea { min-height: 54px; resize: vertical; }",
+      "textarea.urls { font-family: var(--code-font-family, monospace); font-size: 12px; }",
+      ".check { display: flex; align-items: center; gap: 6px; font-size: 13px; margin: 4px 0; }",
+      ".section { border-top: 1px solid var(--divider-color, #eee); margin-top: 12px; padding-top: 8px; }",
+      ".section h4 { margin: 4px 0 8px; font-size: 13px; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.7; }",
+      ".hint { font-size: 12px; opacity: 0.7; margin: 2px 0 8px; }",
+      ".sub { border: 1px solid var(--divider-color, #ccc); border-radius: 8px; padding: 8px; margin: 8px 0; }",
+      ".actions { display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; align-items: center; }",
+      "button.primary, button.small { cursor: pointer; font: inherit; border-radius: 4px; }",
+      "button.primary { background: var(--primary-color, #03a9f4); color: var(--text-on-primary-color, #fff); border: none; padding: 8px 18px; }",
+      "button.small { background: transparent; border: 1px solid var(--divider-color, #ccc); color: var(--primary-text-color, #111); padding: 2px 8px; font-size: 12px; }",
+      ".status { font-size: 12px; opacity: 0.8; }",
+      ".warn { color: var(--warning-color, #ffa600); font-size: 12px; margin: 4px 0; }",
+      ".error { color: var(--error-color, #db4437); font-size: 12px; margin: 4px 0; }",
+      ".devchips { display: flex; flex-wrap: wrap; gap: 10px; }",
+      ".devchips label { min-width: 0; display: flex; align-items: center; gap: 4px; font-size: 13px; }",
+      "pre.yaml { background: var(--secondary-background-color, #f5f5f5); padding: 10px; border-radius: 6px; overflow: auto; font-size: 12px; max-height: 420px; }",
+      "details.more { margin: 8px 0; }",
+      "details.more summary { cursor: pointer; font-size: 13px; opacity: 0.8; }",
+      "ha-select { width: 100%; max-width: 320px; }"
+    ].join("\n");
+    return style;
+  }
+
   // -------------------- the card ----------------------------------------
 
   function defineEditor() {
     if (customElements.get("animated-background-editor")) return;
 
-    var litBase = customElements.get("hui-view") || customElements.get("hui-masonry-view");
-    var html = litBase.html;
-    var css = litBase.css;
-    var LitElement = Object.getPrototypeOf(litBase);
+    var EditorVersion = "v1.1.0-beta.2";
 
-    class AnimatedBackgroundEditor extends LitElement {
-      static get properties() {
-        return {
-          hass: { attribute: false },
-          _tab: { state: true },
-          _form: { state: true },
-          _dirty: { state: true },
-          _status: { state: true },
-          _yamlOut: { state: true },
-          _warnings: { state: true }
-        };
-      }
-
-      static get styles() {
-        return css`
-          :host {
-            display: block;
-          }
-          .head {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 8px;
-            margin-bottom: 8px;
-          }
-          .title {
-            font-weight: 600;
-          }
-          .tabs {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 4px;
-            margin-bottom: 12px;
-          }
-          .tabs button {
-            border: 1px solid var(--divider-color, #ccc);
-            background: transparent;
-            color: var(--primary-text-color, #111);
-            border-radius: 16px;
-            padding: 4px 12px;
-            cursor: pointer;
-            font-size: 13px;
-          }
-          .tabs button[active] {
-            background: var(--primary-color, #03a9f4);
-            border-color: var(--primary-color, #03a9f4);
-            color: var(--text-on-primary-color, #fff);
-          }
-          .row {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            margin-bottom: 8px;
-            flex-wrap: wrap;
-          }
-          .row label {
-            min-width: 170px;
-            font-size: 13px;
-          }
-          .grow {
-            flex: 1;
-            min-width: 200px;
-          }
-          input[type="text"], input[type="number"], textarea, select {
-            width: 100%;
-            box-sizing: border-box;
-            padding: 6px 8px;
-            border: 1px solid var(--divider-color, #ccc);
-            border-radius: 4px;
-            background: var(--card-background-color, #fff);
-            color: var(--primary-text-color, #111);
-            font: inherit;
-          }
-          textarea {
-            min-height: 54px;
-            resize: vertical;
-          }
-          textarea.urls {
-            font-family: var(--code-font-family, monospace);
-            font-size: 12px;
-          }
-          .check {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 13px;
-            margin: 4px 0;
-          }
-          .section {
-            border-top: 1px solid var(--divider-color, #eee);
-            margin-top: 12px;
-            padding-top: 8px;
-          }
-          .section h4 {
-            margin: 4px 0 8px;
-            font-size: 13px;
-            text-transform: uppercase;
-            letter-spacing: 0.04em;
-            opacity: 0.7;
-          }
-          .hint {
-            font-size: 12px;
-            opacity: 0.7;
-            margin: 2px 0 8px;
-          }
-          .sub {
-            border: 1px solid var(--divider-color, #ccc);
-            border-radius: 8px;
-            padding: 8px;
-            margin: 8px 0;
-          }
-          .actions {
-            display: flex;
-            gap: 8px;
-            margin-top: 12px;
-            flex-wrap: wrap;
-          }
-          button.primary, button.small {
-            cursor: pointer;
-            font: inherit;
-            border-radius: 4px;
-          }
-          button.primary {
-            background: var(--primary-color, #03a9f4);
-            color: var(--text-on-primary-color, #fff);
-            border: none;
-            padding: 8px 18px;
-          }
-          button.small {
-            background: transparent;
-            border: 1px solid var(--divider-color, #ccc);
-            color: var(--primary-text-color, #111);
-            padding: 2px 8px;
-            font-size: 12px;
-          }
-          .status {
-            font-size: 12px;
-            opacity: 0.8;
-            align-self: center;
-          }
-          .warn {
-            color: var(--warning-color, #ffa600);
-            font-size: 12px;
-            margin: 4px 0;
-          }
-          .devchips {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 10px;
-          }
-          .devchips label {
-            min-width: 0;
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            font-size: 13px;
-          }
-          pre.yaml {
-            background: var(--secondary-background-color, #f5f5f5);
-            padding: 10px;
-            border-radius: 6px;
-            overflow: auto;
-            font-size: 12px;
-            max-height: 420px;
-          }
-        `;
-      }
-
+    class AnimatedBackgroundEditor extends HTMLElement {
       constructor() {
         super();
+        this.attachShadow({ mode: "open" });
         this._tab = "general";
         this._dirty = false;
         this._status = "";
+        this._error = "";
         this._yamlOut = "";
         this._warnings = [];
-        this._form = this._emptyForm();
+        this._form = formFromConfig(null, null);
+        this._lovelace = null;
+        this._hass = null;
       }
 
       connectedCallback() {
-        super.connectedCallback();
         this._reload();
       }
 
@@ -1409,24 +1482,50 @@ run();
         return 8;
       }
 
-      _emptyForm() {
-        return formFromConfig(null, null);
+      getGridOptions() {
+        return { rows: 12, columns: 12, min_rows: 6, min_columns: 6 };
       }
 
+      // -------------------- state ------------------------------
+
       _reload() {
-        var lovelace = getLovelace();
-        var config = lovelace && lovelace.config ? lovelace.config.animated_background : null;
-        var views = lovelace && lovelace.config && lovelace.config.views ? lovelace.config.views : [];
+        this._lovelace = getLovelace();
+        this._hass = getHass();
+        var config = this._lovelace && this._lovelace.config
+          ? this._lovelace.config.animated_background : null;
+        var views = this._lovelace && this._lovelace.config
+          && Array.isArray(this._lovelace.config.views) ? this._lovelace.config.views : [];
         this._form = formFromConfig(config, views);
         this._dirty = false;
         this._yamlOut = "";
         this._warnings = [];
+        this._error = "";
+        this._status = "";
+        this._render();
       }
 
       _update(mutator) {
         mutator(this._form);
         this._dirty = true;
-        this.requestUpdate();
+        this._render();
+      }
+
+      _canWrite() {
+        // saveConfig requires an admin user (guide §2.6)
+        var hass = this._hass;
+        if (hass && hass.user && hass.user.is_admin === false) return false;
+        return !!(this._lovelace && typeof this._lovelace.saveConfig === "function");
+      }
+
+      _isYamlMode() {
+        return !(this._lovelace && typeof this._lovelace.saveConfig === "function");
+      }
+
+      _isUncontrolled() {
+        var ll = this._lovelace;
+        if (!ll) return true;
+        if (ll.mode === "generated") return true;
+        return !(ll.config && Array.isArray(ll.config.views));
       }
 
       _validate(form) {
@@ -1437,6 +1536,14 @@ run();
         if (!form.entity && !splitLines(form.default_url).length) {
           warnings.push("No default URL and no entity configured.");
         }
+        var opacity = parseInt(form.opacity, 10);
+        if (form.opacity !== "" && (isNaN(opacity) || opacity < 1 || opacity > 99)) {
+          warnings.push("Opacity should be between 1 and 99, or empty to disable.");
+        }
+        var overlayOpacity = parseOpacity(form.overlay_opacity);
+        if (form.overlay_enabled && overlayOpacity == null) {
+          warnings.push("Overlay opacity should be a number between 0 and 1.");
+        }
         var paths = {};
         (form.views || []).forEach(function (view) {
           var path = String(view.path || "").trim();
@@ -1446,36 +1553,85 @@ run();
           paths[path] = true;
         });
         var names = {};
+        var groupNames = {};
         (form.groups || []).forEach(function (group) {
           var name = String(group.name || "").trim();
           if (name && names[name]) warnings.push("Duplicate group name '" + name + "'.");
+          if (name) groupNames[name] = true;
           names[name] = true;
+        });
+        (form.views || []).forEach(function (view) {
+          if (view.mode === "group") {
+            var group = String(view.group || "").trim();
+            if (group && !groupNames[group]) {
+              warnings.push("View '" + view.path + "' uses group '" + group + "', which is not defined in the Groups tab.");
+            }
+          }
+        });
+        // overlay/opacity warnings on custom sub-forms and groups
+        var checkSub = function (label, sf) {
+          if (!sf) return;
+          var subOpacity = parseInt(sf.opacity, 10);
+          if (sf.opacity !== "" && (isNaN(subOpacity) || subOpacity < 1 || subOpacity > 99)) {
+            warnings.push(label + ": opacity should be between 1 and 99, or empty.");
+          }
+          if (sf.overlay_enabled && parseOpacity(sf.overlay_opacity) == null) {
+            warnings.push(label + ": overlay opacity should be a number between 0 and 1.");
+          }
+        };
+        (form.views || []).forEach(function (view) {
+          if (view.mode === "custom") checkSub("View '" + view.path + "'", view.custom);
+        });
+        (form.groups || []).forEach(function (group) {
+          checkSub("Group '" + (group.name || "?") + "'", group.custom);
         });
         return warnings;
       }
 
-      _save() {
-        this._warnings = this._validate(this._form);
-        var lovelace = getLovelace();
-        var built = configFromForm(this._form);
+      _buildYaml() {
+        var original = this._lovelace && this._lovelace.config
+          ? this._lovelace.config.animated_background : null;
+        var built = configFromForm(this._form, original);
+        return configToYaml(built.animated_background)
+          + assignmentsToYaml(built.assignments);
+      }
 
-        if (!lovelace || typeof lovelace.saveConfig !== "function") {
-          this._yamlOut = configToYaml(built.animated_background) + assignmentsToYaml(built.assignments);
-          this._status = "Dashboard is YAML-mode: copy the generated block into your configuration file.";
+      async _save() {
+        this._error = "";
+        this._warnings = this._validate(this._form);
+
+        if (this._isUncontrolled()) {
+          this._yamlOut = this._buildYaml();
+          this._status = "";
+          this._error = "This dashboard has not been taken control of yet, so there is no stored configuration to write to. Edit the dashboard once and confirm Home Assistant's take-control prompt, then save here.";
+          this._render();
           return;
         }
 
-        var newConfig = JSON.parse(JSON.stringify(lovelace.config));
+        if (!this._canWrite()) {
+          this._yamlOut = this._buildYaml();
+          this._status = "";
+          this._error = this._isYamlMode()
+            ? "This dashboard is YAML-mode: copy the generated block into your configuration file. View assignments are included as comments."
+            : "Saving requires an administrator account. Copy the generated YAML instead, or sign in as an admin.";
+          this._render();
+          return;
+        }
+
+        var built = configFromForm(this._form, this._lovelace.config.animated_background);
+        var newConfig = JSON.parse(JSON.stringify(this._lovelace.config));
         if (Object.keys(built.animated_background).length > 0) {
           newConfig.animated_background = built.animated_background;
         } else {
           delete newConfig.animated_background;
         }
-        newConfig.views = (newConfig.views || []).map(function (view) {
-          var path = view.path != null ? String(view.path) : null;
-          if (path == null || !(path in built.assignments)) return view;
+        // same identity rule as the read path: path when the view has
+        // one, array position otherwise (guide §2.5)
+        newConfig.views = (newConfig.views || []).map(function (view, index) {
+          var identity = viewIdentity(view, index);
+          if (!(identity in built.assignments)) return view;
           var copy = Object.assign({}, view);
-          var assignment = built.assignments[path];
+          var assignment = built.assignments[identity];
           if (assignment === undefined) {
             delete copy.animated_background;
           } else {
@@ -1485,356 +1641,553 @@ run();
         });
 
         try {
-          lovelace.saveConfig(newConfig);
+          await this._lovelace.saveConfig(newConfig);
         } catch (err) {
-          this._status = "Save failed: " + err;
+          this._status = "";
+          this._error = "Save failed: " + (err && err.message ? err.message : err);
+          this._render();
           return;
         }
 
-        // re-read config and redraw the background immediately
+        // reset ALL render state before redrawing, so an overlay or
+        // background edit on an entity-less config rebuilds the iframe
+        // instead of showing stale pixels (guide §2.4)
         try {
           getVars();
           Previous_Config = null;
+          Previous_Url = null;
+          Previous_State = null;
+          Previous_Entity = null;
+          Previous_Last_Updated = null;
+          clearMemes();
+          clearRefreshTimer();
           renderBackgroundHTML();
         } catch (err) {
-          // editor still saved successfully even if the live redraw hiccups
+          // the save succeeded; a redraw hiccup must not report failure
         }
 
         this._yamlOut = "";
         this._dirty = false;
         this._status = "Saved " + new Date().toLocaleTimeString();
+        this._render();
       }
 
       _copyYaml() {
-        var text = this._yamlOut || configToYaml(configFromForm(this._form).animated_background);
-        navigator.clipboard.writeText(text).then(
-          function () { this._status = "YAML copied to clipboard"; this.requestUpdate(); }.bind(this),
-          function () { this._status = "Copy failed, select the text manually"; this.requestUpdate(); }.bind(this)
-        );
+        var self = this;
+        var text = this._yamlOut || this._buildYaml();
+        copyText(text, function (ok) {
+          self._status = ok ? "YAML copied to clipboard"
+            : "Copy failed — select the YAML text manually";
+          self._render();
+        });
       }
 
-      // -------------------- sub-form templates ---------------------------
+      // -------------------- control factories ------------------
 
-      _subForm(form, onEntity, onDefaultUrl, onState, onAddState, onRemoveState, onOverlay, opts) {
-        var states = form.states;
-        var currentState = "";
-        if (this.hass && form.entity && this.hass.states[form.entity]) {
-          currentState = this.hass.states[form.entity].state;
+      _textField(value, opts, onchange) {
+        var handler = function (e) { onchange(e.target.value); };
+        var HaText = customElements.get("ha-textfield");
+        // ha-textfield where available, native input otherwise; every
+        // supplied option is applied as a property/attribute so min, max
+        // and step reach the element too, not just type and placeholder
+        var input = document.createElement(HaText ? "ha-textfield" : "input");
+        input.value = value == null ? "" : String(value);
+        ["type", "placeholder", "min", "max", "step"].forEach(function (k) {
+          var v = opts ? opts[k] : null;
+          if (v == null) return;
+          if (k in input) input[k] = v;
+          else input.setAttribute(k, v);
+        });
+        input.addEventListener("change", handler);
+        return input;
+      }
+
+      _numberField(value, opts, onchange) {
+        return this._textField(value, Object.assign({ type: "number" }, opts), onchange);
+      }
+
+      _area(value, cls, placeholder, onchange) {
+        return h("textarea", {
+          class: cls, value: value == null ? "" : String(value),
+          placeholder: placeholder || "",
+          onchange: function (e) { onchange(e.target.value); }
+        });
+      }
+
+      _check(checked, label, onchange) {
+        var HaSwitch = customElements.get("ha-switch");
+        var control;
+        if (HaSwitch) {
+          control = document.createElement("ha-switch");
+          control.checked = !!checked;
+          control.addEventListener("change", function (e) { onchange(e.target.checked); });
+        } else {
+          control = h("input", {
+            type: "checkbox", checked: !!checked,
+            onchange: function (e) { onchange(e.target.checked); }
+          });
         }
-        return html`
-          <div class="row">
-            <label>Entity</label>
-            <input class="grow" type="text" .value=${form.entity}
-              list="abe-entity-list" @change=${onEntity} placeholder="e.g. weather.home">
-          </div>
-          ${currentState ? html`<div class="hint">Current state of ${form.entity}: ${currentState}</div>` : ""}
-          ${opts && opts.hideDefaultUrl ? "" : html`
-            <div class="row">
-              <label>Default URL(s)</label>
-              <textarea class="urls grow" .value=${form.default_url} @change=${onDefaultUrl}
-                placeholder="One URL per line. Multiple lines = random choice"></textarea>
-            </div>
-          `}
-          <div class="hint">One URL per line. Multiple lines for a state = a random URL is picked each refresh.</div>
-          ${states.map(function (row, index) {
-            return html`
-              <div class="row">
-                <input style="max-width:160px" type="text" placeholder="state" .value=${row.state}
-                  @change=${function (e) { onState(index, "state", e.target.value); }}>
-                <textarea class="urls grow" placeholder="URL(s) for this state" .value=${row.urls}
-                  @change=${function (e) { onState(index, "urls", e.target.value); }}></textarea>
-                <button class="small" type="button" @click=${function () { onRemoveState(index); }}>Remove</button>
-              </div>
-            `;
-          })}
-          <div class="row">
-            <button class="small" type="button" @click=${onAddState}>Add state</button>
-          </div>
-          ${opts && opts.hideOverlay ? "" : html`
-            <div class="check">
-              <input type="checkbox" id="ovr" .checked=${form.overlay_enabled} @change=${onOverlay.toggle}>
-              <label for="ovr">Tint overlay</label>
-            </div>
-            ${form.overlay_enabled ? html`
-              <div class="row">
-                <label>Overlay color</label>
-                <input style="max-width:120px" type="text" .value=${form.overlay_color} @change=${onOverlay.color}>
-                <label style="min-width:0">Opacity (0-1)</label>
-                <input style="max-width:80px" type="number" min="0" max="1" step="0.05"
-                  .value=${form.overlay_opacity} @change=${onOverlay.opacity}>
-              </div>
-            ` : ""}
-          `}
-        `;
+        return h("label", { class: "check" }, control, label);
       }
 
-      // -------------------- tabs ------------------------------------------
+      // value is set in exactly one place — on the select — never on the
+      // options, so re-renders cannot fight the selected state (§2.6)
+      _select(value, options, onchange) {
+        var HaSelect = customElements.get("ha-select");
+        var sel;
+        if (HaSelect) {
+          sel = document.createElement("ha-select");
+          options.forEach(function (o) {
+            var item = document.createElement("ha-list-item");
+            item.value = o[0];
+            item.textContent = o[1];
+            sel.appendChild(item);
+          });
+        } else {
+          sel = document.createElement("select");
+          options.forEach(function (o) {
+            var opt = document.createElement("option");
+            opt.value = o[0];
+            opt.textContent = o[1];
+            sel.appendChild(opt);
+          });
+        }
+        sel.value = value;
+        sel.addEventListener("change", function (e) { onchange(e.target.value); });
+        return sel;
+      }
+
+      _entityPicker(value, onchange) {
+        var self = this;
+        var HaPicker = customElements.get("ha-entity-picker");
+        if (HaPicker && this._hass) {
+          var picker = document.createElement("ha-entity-picker");
+          picker.hass = this._hass;
+          picker.value = value || "";
+          picker.allowCustomEntity = true;
+          picker.addEventListener("value-changed", function (e) {
+            onchange(e.detail && e.detail.value ? e.detail.value : "");
+          });
+          return picker;
+        }
+        var listId = "abe-entity-list";
+        var entities = this._hass ? Object.keys(this._hass.states).sort() : [];
+        var datalist = h("datalist", { id: listId },
+          entities.map(function (id) { return h("option", { value: id }); }));
+        var input = this._textField(value, { placeholder: "e.g. weather.home" }, onchange);
+        input.setAttribute("list", listId);
+        return h("span", { class: "grow", style: "display:flex;flex-direction:column" }, input, datalist);
+      }
+
+      _row(labelText, control, hint) {
+        var kids = [];
+        if (labelText) kids.push(h("label", {}, labelText));
+        kids.push(control);
+        var row = h("div", { class: "row" }, kids);
+        if (hint) row.appendChild(h("div", { class: "hint", style: "flex-basis:100%" }, hint));
+        return row;
+      }
+
+      // -------------------- sub-form ----------------------------
+
+      // api: { patch(changes), addState(), removeState(i), stateField(i, key, v) }
+      _subForm(sf, api, opts) {
+        opts = opts || {};
+        var self = this;
+        var wrap = h("div", {});
+
+        if (!opts.hideEntity) {
+          wrap.appendChild(this._row("Entity",
+            this._entityPicker(sf.entity, function (v) { api.patch({ entity: v }); })));
+          var hass = this._hass;
+          var entityState = hass && sf.entity && hass.states[sf.entity]
+            ? hass.states[sf.entity].state : "";
+          if (entityState !== "") {
+            wrap.appendChild(h("div", { class: "hint" },
+              "Current state of " + sf.entity + ": " + entityState));
+          }
+        }
+
+        if (!opts.hideDefaultUrl) {
+          wrap.appendChild(this._row("Default URL(s)",
+            this._area(sf.default_url, "urls grow",
+              "One URL per line. Multiple lines = random choice",
+              function (v) { api.patch({ default_url: v }); }),
+            "One URL per line. Multiple lines for a state = a random URL is picked each refresh. Set a state's URL to none to disable the background for that state."));
+        }
+
+        (sf.states || []).forEach(function (row, index) {
+          wrap.appendChild(h("div", { class: "row" },
+            h("input", {
+              type: "text", value: row.state, placeholder: "state",
+              style: "max-width:160px",
+              onchange: function (e) { api.stateField(index, "state", e.target.value); }
+            }),
+            h("textarea", {
+              class: "urls grow", value: row.urls,
+              placeholder: "URL(s) for this state",
+              onchange: function (e) { api.stateField(index, "urls", e.target.value); }
+            }),
+            h("button", {
+              class: "small", type: "button", text: "Remove",
+              onclick: function () { api.removeState(index); }
+            })));
+        });
+        wrap.appendChild(h("div", { class: "row" },
+          h("button", {
+            class: "small", type: "button", text: "Add state",
+            onclick: function () { api.addState(); }
+          })));
+
+        var more = h("div", {});
+        more.appendChild(this._row("Background override",
+          this._textField(sf.background, {
+            placeholder: "'transparent' or any CSS background"
+          }, function (v) { api.patch({ background: v }); }),
+          "Overrides the default transparent background the card paints behind the header."));
+        more.appendChild(this._row("Opacity (1-99)",
+          this._numberField(sf.opacity, { placeholder: "empty = disabled" },
+            function (v) { api.patch({ opacity: v }); })));
+        more.appendChild(this._check(sf.transparent_panel, "Transparent top panel",
+          function (v) { api.patch({ transparent_panel: v }); }));
+        more.appendChild(this._check(sf.overlay_enabled, "Tint overlay",
+          function (v) { api.patch({ overlay_enabled: v }); }));
+        if (sf.overlay_enabled) {
+          more.appendChild(this._row("Overlay color",
+            h("span", { style: "display:flex;gap:8px;align-items:center" },
+              this._textField(sf.overlay_color, { type: "text" },
+                function (v) { api.patch({ overlay_color: v }); }),
+              this._numberField(sf.overlay_opacity, { min: "0", max: "1", step: "0.05" },
+                function (v) { api.patch({ overlay_opacity: v }); }))));
+        }
+        more.appendChild(this._row("Refresh interval (minutes)",
+          this._numberField(sf.refresh_interval, { placeholder: "empty = never" },
+            function (v) { api.patch({ refresh_interval: v }); })));
+        more.appendChild(this._check(sf.refresh_on_update,
+          "Refresh when the entity updates, even if the state is unchanged",
+          function (v) { api.patch({ refresh_on_update: v }); }));
+        more.appendChild(h("div", { class: "hint" },
+          "Users: comma or newline separated Home Assistant usernames."));
+        more.appendChild(this._row("Included users",
+          this._area(sf.included_users, "grow", "", function (v) { api.patch({ included_users: v }); })));
+        more.appendChild(this._row("Excluded users",
+          this._area(sf.excluded_users, "grow", "", function (v) { api.patch({ excluded_users: v }); })));
+        ["included_devices", "excluded_devices"].forEach(function (field) {
+          var label = field === "included_devices"
+            ? "Included devices (empty = all)" : "Excluded devices";
+          var chips = h("div", { class: "devchips" });
+          KNOWN_DEVICES.forEach(function (device) {
+            var checked = (sf[field] || []).indexOf(device) !== -1;
+            chips.appendChild(h("label", {},
+              h("input", {
+                type: "checkbox", checked: checked,
+                onchange: function (e) {
+                  var list = (sf[field] || []).slice();
+                  var at = list.indexOf(device);
+                  if (e.target.checked && at === -1) list.push(device);
+                  if (!e.target.checked && at !== -1) list.splice(at, 1);
+                  var changes = {};
+                  changes[field] = list;
+                  api.patch(changes);
+                }
+              }), device));
+          });
+          more.appendChild(h("div", { class: "section" },
+            h("h4", {}, label), chips));
+        });
+        more.appendChild(h("div", { class: "hint" },
+          "Device types are matched against the browser user agent. Use debug + \"show user agent\" on the Advanced tab to find the right value."));
+
+        if (!opts.hideMore) {
+          wrap.appendChild(h("details", { class: "more" },
+            h("summary", {}, "More options"), more));
+        }
+        return wrap;
+      }
+
+      // -------------------- tabs --------------------------------
 
       _renderGeneral() {
+        var self = this;
         var form = this._form;
-        return html`
-          <div class="check">
-            <input type="checkbox" id="en" .checked=${form.enabled}
-              @change=${function (e) { this._update(function (f) { f.enabled = e.target.checked; }); }.bind(this)}>
-            <label for="en">Background enabled</label>
-          </div>
-          <div class="row">
-            <label>Default URL(s)</label>
-            <textarea class="urls grow" .value=${form.default_url}
-              @change=${function (e) { this._update(function (f) { f.default_url = e.target.value; }); }.bind(this)}
-              placeholder="One URL per line. Multiple lines = random choice"></textarea>
-          </div>
-          <div class="row">
-            <label>Transparent top panel</label>
-            <input type="checkbox" .checked=${form.transparent_panel}
-              @change=${function (e) { this._update(function (f) { f.transparent_panel = e.target.checked; }); }.bind(this)}>
-          </div>
-          <div class="row">
-            <label>Card opacity (1-99)</label>
-            <input style="max-width:90px" type="number" min="1" max="99" .value=${form.opacity}
-              @change=${function (e) { this._update(function (f) { f.opacity = e.target.value; }); }.bind(this)}>
-            <span class="hint">Empty = disabled. Makes cards see-through with a compatible theme. Creates a CSS stacking context (see README).</span>
-          </div>
-          <div class="check">
-            <input type="checkbox" id="ov" .checked=${form.overlay_enabled}
-              @change=${function (e) { this._update(function (f) { f.overlay_enabled = e.target.checked; }); }.bind(this)}>
-            <label for="ov">Tint overlay over the background</label>
-          </div>
-          ${form.overlay_enabled ? html`
-            <div class="row">
-              <label>Overlay color</label>
-              <input style="max-width:120px" type="text" .value=${form.overlay_color}
-                @change=${function (e) { this._update(function (f) { f.overlay_color = e.target.value; }); }.bind(this)}>
-              <label style="min-width:0">Opacity (0-1)</label>
-              <input style="max-width:80px" type="number" min="0" max="1" step="0.05" .value=${form.overlay_opacity}
-                @change=${function (e) { this._update(function (f) { f.overlay_opacity = e.target.value; }); }.bind(this)}>
-            </div>
-          ` : ""}
-          <div class="row">
-            <label>Refresh interval (minutes)</label>
-            <input style="max-width:90px" type="number" min="1" .value=${form.refresh_interval}
-              @change=${function (e) { this._update(function (f) { f.refresh_interval = e.target.value; }); }.bind(this)}>
-            <span class="hint">Empty = never. Re-picks from the current URL list.</span>
-          </div>
-          <div class="check">
-            <input type="checkbox" id="rou" .checked=${form.refresh_on_update}
-              @change=${function (e) { this._update(function (f) { f.refresh_on_update = e.target.checked; }); }.bind(this)}>
-            <label for="rou">Refresh when the entity updates, even if the state is unchanged</label>
-          </div>
-        `;
+        var wrap = h("div", {});
+        wrap.appendChild(this._check(form.enabled, "Background enabled",
+          function (v) { self._update(function (f) { f.enabled = v; }); }));
+        wrap.appendChild(this._row("Default URL(s)",
+          this._area(form.default_url, "urls grow",
+            "One URL per line. Multiple lines = random choice",
+            function (v) { self._update(function (f) { f.default_url = v; }); }),
+          "One URL per line. Multiple lines = a random URL is picked each refresh."));
+        wrap.appendChild(this._row("Background override",
+          this._textField(form.background, {
+            placeholder: "'transparent' or any CSS background"
+          }, function (v) { self._update(function (f) { f.background = v; }); }),
+          "Overrides the default transparent background Home Assistant paints behind the header."));
+        wrap.appendChild(this._row("Opacity (1-99)",
+          this._numberField(form.opacity, { placeholder: "empty = disabled" },
+            function (v) { self._update(function (f) { f.opacity = v }); }),
+          "Empty = disabled. Makes cards see-through with a compatible theme. Creates a CSS stacking context (see README)."));
+        wrap.appendChild(this._check(form.transparent_panel, "Transparent top panel",
+          function (v) { self._update(function (f) { f.transparent_panel = v; }); }));
+        wrap.appendChild(this._check(form.overlay_enabled, "Tint overlay over the background",
+          function (v) { self._update(function (f) { f.overlay_enabled = v; }); }));
+        if (form.overlay_enabled) {
+          wrap.appendChild(this._row("Overlay color",
+            h("span", { style: "display:flex;gap:8px;align-items:center" },
+              this._textField(form.overlay_color, {},
+                function (v) { self._update(function (f) { f.overlay_color = v; }); }),
+              this._numberField(form.overlay_opacity, { min: "0", max: "1", step: "0.05" },
+                function (v) { self._update(function (f) { f.overlay_opacity = v; }); }))));
+        }
+        wrap.appendChild(this._row("Refresh interval (minutes)",
+          this._numberField(form.refresh_interval, { placeholder: "empty = never" },
+            function (v) { self._update(function (f) { f.refresh_interval = v; }); }),
+          "Empty = never. Re-picks from the current URL list."));
+        wrap.appendChild(this._check(form.refresh_on_update,
+          "Refresh when the entity updates, even if the state is unchanged",
+          function (v) { self._update(function (f) { f.refresh_on_update = v; }); }));
+        return wrap;
       }
 
       _renderStates() {
-        var form = this._form;
         var self = this;
-        return html`
-          ${this._subForm(
-            { entity: form.entity, default_url: "", states: form.states, overlay_enabled: false,
-              overlay_color: "#000000", overlay_opacity: "0.3" },
-            function (e) { self._update(function (f) { f.entity = e.target.value; }); },
-            function () {},
-            function (index, field, value) {
-              self._update(function (f) { f.states[index][field] = value; });
+        var form = this._form;
+        var wrap = this._subForm(
+          { entity: form.entity, states: form.states },
+          {
+            patch: function (changes) {
+              // only the entity field belongs to the root form on this
+              // tab; the "More options" block is hidden entirely
+              if ("entity" in changes) {
+                self._update(function (f) { f.entity = changes.entity; });
+              }
             },
-            function () {
+            stateField: function (index, key, value) {
+              self._update(function (f) { f.states[index][key] = value; });
+            },
+            addState: function () {
               self._update(function (f) { f.states.push({ state: "", urls: "" }); });
             },
-            function (index) {
+            removeState: function (index) {
               self._update(function (f) { f.states.splice(index, 1); });
-            },
-            {
-              toggle: function () {},
-              color: function () {},
-              opacity: function () {}
-            },
-            { hideDefaultUrl: true, hideOverlay: true }
-          )}
-          <div class="hint">Maps states of the entity above to background URLs. States without an entry fall back to the default URL. Set a state's URL to <b>none</b> to disable the background for that state.</div>
-        `;
+            }
+          },
+          { hideDefaultUrl: true, hideMore: true });
+        wrap.appendChild(h("div", { class: "hint" },
+          "Maps states of the entity above to background URLs. States without an entry fall back to the default URL."));
+        return wrap;
       }
 
       _renderViews() {
         var self = this;
         var form = this._form;
-        var groupNames = (form.groups || []).map(function (g) { return g.name; }).filter(Boolean);
-        return html`
-          <div class="hint">Per-view overrides. "Inherit" uses the root config (and any group assigned to the view). Group/None assignments are written onto the dashboard view definitions on save.</div>
-          ${(form.views || []).map(function (view, index) {
-            var isCustom = view.mode === "custom";
-            return html`
-              <div class="sub">
-                <div class="row">
-                  <b>${view.title || view.path}</b>
-                  <span class="hint">${view.path}${view.orphan ? " (stale entry)" : ""}</span>
-                </div>
-                <div class="row">
-                  <label>Background</label>
-                  <select .value=${view.mode}
-                    @change=${function (e) {
-                      self._update(function (f) { f.views[index].mode = e.target.value; });
-                    }}>
-                    <option value="inherit">Inherit root config</option>
-                    <option value="group">Use a group</option>
-                    <option value="none">Disabled ('none')</option>
-                    <option value="custom">Custom config</option>
-                  </select>
-                  ${view.mode === "group" ? html`
-                    <select .value=${view.group}
-                      @change=${function (e) {
-                        self._update(function (f) { f.views[index].group = e.target.value; });
-                      }}>
-                      <option value="">Choose group...</option>
-                      ${groupNames.map(function (name) {
-                        return html`<option value=${name} ?selected=${name === view.group}>${name}</option>`;
-                      })}
-                    </select>
-                  ` : ""}
-                </div>
-                ${isCustom ? html`
-                  <div class="sub">
-                    ${self._subForm(
-                      view.custom,
-                      function (e) { self._update(function (f) { f.views[index].custom.entity = e.target.value; }); },
-                      function (e) { self._update(function (f) { f.views[index].custom.default_url = e.target.value; }); },
-                      function (si, field, value) {
-                        self._update(function (f) { f.views[index].custom.states[si][field] = value; });
-                      },
-                      function () {
-                        self._update(function (f) { f.views[index].custom.states.push({ state: "", urls: "" }); });
-                      },
-                      function (si) {
-                        self._update(function (f) { f.views[index].custom.states.splice(si, 1); });
-                      },
-                      {
-                        toggle: function (e) { self._update(function (f) { f.views[index].custom.overlay_enabled = e.target.checked; }); },
-                        color: function (e) { self._update(function (f) { f.views[index].custom.overlay_color = e.target.value; }); },
-                        opacity: function (e) { self._update(function (f) { f.views[index].custom.overlay_opacity = e.target.value; }); }
-                      }
-                    )}
-                  </div>
-                ` : ""}
-              </div>
-            `;
-          })}
-          ${(form.views || []).length === 0 ? html`<div class="hint">This dashboard has no views yet.</div>` : ""}
-        `;
+        var wrap = h("div", {});
+        wrap.appendChild(h("div", { class: "hint" },
+          "Per-view overrides. \"Inherit\" uses the root config (and any group assigned to the view). Group and None assignments are written onto the dashboard view definitions on save."));
+        (form.views || []).forEach(function (view, index) {
+          var block = h("div", { class: "sub" });
+          block.appendChild(h("div", { class: "row" },
+            h("b", {}, view.title || view.path),
+            h("span", { class: "hint" },
+              view.path + (view.orphan ? " (stale entry)" : "")),
+            view.orphan
+              ? h("button", {
+                  class: "small", type: "button", text: "Remove stale entry",
+                  onclick: function () {
+                    self._update(function (f) { f.views.splice(index, 1); });
+                  }
+                })
+              : null));
+          block.appendChild(self._row("Background",
+            self._select(view.mode, [
+              ["inherit", "Inherit root config"],
+              ["group", "Use a group"],
+              ["none", "Disabled ('none')"],
+              ["custom", "Custom config"]
+            ], function (v) {
+              self._update(function (f) { f.views[index].mode = v; });
+            })));
+          if (view.mode === "group") {
+            var groupNames = (form.groups || []).map(function (g) { return g.name; })
+              .filter(function (n) { return n; });
+            block.appendChild(self._row("Group",
+              self._select(view.group, [["", "Choose group..."]].concat(
+                groupNames.map(function (name) { return [name, name]; })),
+              function (v) {
+                self._update(function (f) { f.views[index].group = v; });
+              }),
+              groupNames.indexOf(view.group) === -1 && view.group
+                ? "This group is not defined in the Groups tab."
+                : ""));
+          }
+          if (view.mode === "custom") {
+            var custom = h("div", { class: "sub" });
+            custom.appendChild(self._subForm(view.custom, {
+              patch: function (changes) {
+                self._update(function (f) { Object.assign(f.views[index].custom, changes); });
+              },
+              stateField: function (si, key, value) {
+                self._update(function (f) { f.views[index].custom.states[si][key] = value; });
+              },
+              addState: function () {
+                self._update(function (f) {
+                  f.views[index].custom.states.push({ state: "", urls: "" });
+                });
+              },
+              removeState: function (si) {
+                self._update(function (f) { f.views[index].custom.states.splice(si, 1); });
+              }
+            }));
+            block.appendChild(custom);
+          }
+          wrap.appendChild(block);
+        });
+        if (!(form.views || []).length) {
+          wrap.appendChild(h("div", { class: "hint" }, "This dashboard has no views yet."));
+        }
+        return wrap;
       }
 
       _renderGroups() {
         var self = this;
         var form = this._form;
-        return html`
-          <div class="hint">Named reusable configurations. Assign them to views in the Views tab, or set <b>animated_background: &lt;group name&gt;</b> on a view definition.</div>
-          ${(form.groups || []).map(function (group, index) {
-            return html`
-              <div class="sub">
-                <div class="row">
-                  <label>Group name</label>
-                  <input class="grow" type="text" .value=${group.name}
-                    @change=${function (e) {
-                      self._update(function (f) { f.groups[index].name = e.target.value; });
-                    }}>
-                  <button class="small" type="button"
-                    @click=${function () { self._update(function (f) { f.groups.splice(index, 1); }); }}>Remove group</button>
-                </div>
-                ${self._subForm(
-                  group.custom,
-                  function (e) { self._update(function (f) { f.groups[index].custom.entity = e.target.value; }); },
-                  function (e) { self._update(function (f) { f.groups[index].custom.default_url = e.target.value; }); },
-                  function (si, field, value) {
-                    self._update(function (f) { f.groups[index].custom.states[si][field] = value; });
-                  },
-                  function () {
-                    self._update(function (f) { f.groups[index].custom.states.push({ state: "", urls: "" }); });
-                  },
-                  function (si) {
-                    self._update(function (f) { f.groups[index].custom.states.splice(si, 1); });
-                  },
-                  {
-                    toggle: function (e) { self._update(function (f) { f.groups[index].custom.overlay_enabled = e.target.checked; }); },
-                    color: function (e) { self._update(function (f) { f.groups[index].custom.overlay_color = e.target.value; }); },
-                    opacity: function (e) { self._update(function (f) { f.groups[index].custom.overlay_opacity = e.target.value; }); }
-                  }
-                )}
-              </div>
-            `;
-          })}
-          <div class="row">
-            <button class="small" type="button"
-              @click=${function () {
-                self._update(function (f) {
-                  f.groups.push({ name: "", custom: subFormFromConfig(null) });
-                });
-              }}>Add group</button>
-          </div>
-        `;
+        var wrap = h("div", {});
+        wrap.appendChild(h("div", { class: "hint" },
+          "Named reusable configurations. Assign them to views in the Views tab, or set animated_background: <group name> on a view definition."));
+        (form.groups || []).forEach(function (group, index) {
+          var block = h("div", { class: "sub" });
+          block.appendChild(self._row("Group name",
+            h("span", { style: "display:flex;gap:8px;flex:1" },
+              self._textField(group.name, {},
+                function (v) {
+                  self._update(function (f) { f.groups[index].name = v; });
+                }),
+              h("button", {
+                class: "small", type: "button", text: "Remove group",
+                onclick: function () {
+                  self._update(function (f) { f.groups.splice(index, 1); });
+                }
+              }))));
+          block.appendChild(self._subForm(group.custom, {
+            patch: function (changes) {
+              self._update(function (f) { Object.assign(f.groups[index].custom, changes); });
+            },
+            stateField: function (si, key, value) {
+              self._update(function (f) { f.groups[index].custom.states[si][key] = value; });
+            },
+            addState: function () {
+              self._update(function (f) {
+                f.groups[index].custom.states.push({ state: "", urls: "" });
+              });
+            },
+            removeState: function (si) {
+              self._update(function (f) { f.groups[index].custom.states.splice(si, 1); });
+            }
+          }));
+          wrap.appendChild(block);
+        });
+        wrap.appendChild(h("div", { class: "row" },
+          h("button", {
+            class: "small", type: "button", text: "Add group",
+            onclick: function () {
+              self._update(function (f) {
+                f.groups.push({ name: "", custom: subFormFromConfig(null) });
+              });
+            }
+          })));
+        return wrap;
       }
 
       _renderAccess() {
         var self = this;
         var form = this._form;
-        var deviceRow = function (field) {
-          return html`
-            <div class="devchips">
-              ${KNOWN_DEVICES.map(function (device) {
-                var checked = (form[field] || []).indexOf(device) !== -1;
-                return html`
-                  <label>
-                    <input type="checkbox" .checked=${checked}
-                      @change=${function (e) {
-                        self._update(function (f) {
-                          var list = f[field];
-                          var at = list.indexOf(device);
-                          if (e.target.checked && at === -1) list.push(device);
-                          if (!e.target.checked && at !== -1) list.splice(at, 1);
-                        });
-                      }}>
-                    ${device}
-                  </label>
-                `;
-              })}
-            </div>
-          `;
-        };
-        return html`
-          <div class="section">
-            <h4>Included users (empty = everyone)</h4>
-            <textarea class="grow" .value=${form.included_users}
-              @change=${function (e) { self._update(function (f) { f.included_users = e.target.value; }); }}></textarea>
-            <h4>Excluded users</h4>
-            <textarea class="grow" .value=${form.excluded_users}
-              @change=${function (e) { self._update(function (f) { f.excluded_users = e.target.value; }); }}></textarea>
-            <div class="hint">Comma or newline separated Home Assistant usernames.</div>
-          </div>
-          <div class="section">
-            <h4>Included devices (empty = all)</h4>
-            ${deviceRow("included_devices")}
-            <h4>Excluded devices</h4>
-            ${deviceRow("excluded_devices")}
-            <div class="hint">Device types are matched against the browser user agent. Use debug + "show user agent" on the Advanced tab to find the right value.</div>
-          </div>
-        `;
+        var wrap = h("div", {});
+        wrap.appendChild(h("div", { class: "section" },
+          h("h4", {}, "Included users (empty = everyone)"),
+          this._area(form.included_users, "grow", "", function (v) {
+            self._update(function (f) { f.included_users = v; });
+          }),
+          h("h4", {}, "Excluded users"),
+          this._area(form.excluded_users, "grow", "", function (v) {
+            self._update(function (f) { f.excluded_users = v; });
+          }),
+          h("div", { class: "hint" },
+            "Comma or newline separated Home Assistant usernames.")));
+        var devices = h("div", { class: "section" });
+        ["included_devices", "excluded_devices"].forEach(function (field) {
+          devices.appendChild(h("h4", {},
+            field === "included_devices"
+              ? "Included devices (empty = all)" : "Excluded devices"));
+          var chips = h("div", { class: "devchips" });
+          KNOWN_DEVICES.forEach(function (device) {
+            var checked = (form[field] || []).indexOf(device) !== -1;
+            chips.appendChild(h("label", {},
+              h("input", {
+                type: "checkbox", checked: checked,
+                onchange: function (e) {
+                  self._update(function (f) {
+                    var list = f[field];
+                    var at = list.indexOf(device);
+                    if (e.target.checked && at === -1) list.push(device);
+                    if (!e.target.checked && at !== -1) list.splice(at, 1);
+                  });
+                }
+              }), device));
+          });
+          devices.appendChild(chips);
+        });
+        devices.appendChild(h("div", { class: "hint" },
+          "Device types are matched against the browser user agent. Use debug + \"show user agent\" on the Advanced tab to find the right value."));
+        wrap.appendChild(devices);
+        return wrap;
       }
 
       _renderAdvanced() {
         var self = this;
         var form = this._form;
-        return html`
-          <div class="check">
-            <input type="checkbox" id="dbg" .checked=${form.debug}
-              @change=${function (e) { self._update(function (f) { f.debug = e.target.checked; }); }}>
-            <label for="dbg">Debug logging (browser console)</label>
-          </div>
-          <div class="check">
-            <input type="checkbox" id="ua" .checked=${form.display_user_agent}
-              @change=${function (e) { self._update(function (f) { f.display_user_agent = e.target.checked; }); }}>
-            <label for="ua">Show my user agent on reload (for device lists)</label>
-          </div>
-        `;
+        var wrap = h("div", {});
+        wrap.appendChild(this._check(form.debug, "Debug logging (browser console)",
+          function (v) { self._update(function (f) { f.debug = v; }); }));
+        wrap.appendChild(this._check(form.display_user_agent,
+          "Show my user agent on reload (for device lists)",
+          function (v) { self._update(function (f) { f.display_user_agent = v; }); }));
+        return wrap;
       }
 
-      render() {
+      // -------------------- render -------------------------------
+
+      _render() {
         var self = this;
+        var root = this.shadowRoot;
+        root.innerHTML = "";
+
+        var canWrite = this._canWrite();
+        var uncontrolled = this._isUncontrolled();
+
+        var head = h("div", { class: "head" },
+          h("span", { class: "title" }, "Animated Background"),
+          h("span", { class: "status" }, this._status));
+
+        var container = h("ha-card", {},
+          h("div", { style: "padding: 12px 16px 16px" }, head));
+
+        var inner = container.firstChild;
+
+        // an uncontrolled (strategy-generated) dashboard has no stored
+        // config to write to — explain the take-control step instead of
+        // rendering a form whose save would fail (guide §5)
+        if (uncontrolled) {
+          inner.appendChild(h("p", { class: "hint" },
+            "This dashboard is auto-generated (a strategy controls it). Take control of it first: edit the dashboard once and confirm Home Assistant's take-control prompt. Until then there is no stored configuration for this editor (or a save) to write to."));
+          if (this._yamlOut) {
+            inner.appendChild(this._yamlBlock());
+          }
+          this._actions(inner, false);
+          root.appendChild(styleNode());
+          root.appendChild(container);
+          return;
+        }
+
         var tabs = [
           ["general", "General"],
           ["states", "Entity & States"],
@@ -1843,6 +2196,31 @@ run();
           ["access", "Access"],
           ["advanced", "Advanced"]
         ];
+        var tabBar = h("div", { class: "tabs" });
+        tabs.forEach(function (tab) {
+          var button = h("button", {
+            type: "button", text: tab[1],
+            onclick: function () { self._tab = tab[0]; self._render(); }
+          });
+          if (self._tab === tab[0]) button.setAttribute("active", "");
+          tabBar.appendChild(button);
+        });
+        inner.appendChild(tabBar);
+
+        if (!canWrite) {
+          var note = this._isYamlMode()
+            ? "This dashboard is YAML-mode: changes cannot be saved from here. Use Save to generate the animated_background: block (plus the view-level lines) and paste it into your configuration file."
+            : "You are not signed in as an administrator. Saving requires admin; use Save to generate YAML you can hand to an admin, or paste it into your YAML configuration yourself.";
+          inner.appendChild(h("div", { class: "hint" }, note));
+        }
+
+        this._warnings.forEach(function (warning) {
+          inner.appendChild(h("div", { class: "warn" }, warning));
+        });
+        if (this._error) {
+          inner.appendChild(h("div", { class: "error" }, this._error));
+        }
+
         var body;
         if (this._tab === "general") body = this._renderGeneral();
         else if (this._tab === "states") body = this._renderStates();
@@ -1850,51 +2228,59 @@ run();
         else if (this._tab === "groups") body = this._renderGroups();
         else if (this._tab === "access") body = this._renderAccess();
         else body = this._renderAdvanced();
+        inner.appendChild(body);
 
-        var entityList = this.hass ? Object.keys(this.hass.states) : [];
+        if (this._yamlOut) {
+          inner.appendChild(this._yamlBlock());
+        }
 
-        return html`
-          <ha-card>
-            <div style="padding: 12px 16px 16px">
-              <div class="head">
-                <span class="title">Animated Background</span>
-                <span class="status">${this._status}</span>
-              </div>
-              <div class="tabs">
-                ${tabs.map(function (tab) {
-                  return html`
-                    <button type="button" ?active=${self._tab === tab[0]}
-                      @click=${function () { self._tab = tab[0]; self.requestUpdate(); }}>${tab[1]}</button>
-                  `;
-                })}
-              </div>
-              ${this._warnings.map(function (warning) {
-                return html`<div class="warn">${warning}</div>`;
-              })}
-              ${body}
-              ${this._yamlOut ? html`
-                <div class="section">
-                  <h4>Generated YAML</h4>
-                  <pre class="yaml" id="abe-yaml">${this._yamlOut}</pre>
-                  <div class="row">
-                    <button class="small" type="button" @click=${function () { self._copyYaml(); }}>Copy YAML</button>
-                  </div>
-                </div>
-              ` : ""}
-              <div class="actions">
-                <button class="primary" type="button" ?disabled=${!this._dirty}
-                  @click=${function () { self._save(); }}>Save</button>
-                <button class="small" type="button" @click=${function () { self._reload(); }}>Reload config</button>
-                <button class="small" type="button" @click=${function () { self._copyYaml(); }}>Copy YAML</button>
-              </div>
-            </div>
-          </ha-card>
-          <datalist id="abe-entity-list">
-            ${entityList.map(function (entityId) {
-              return html`<option value=${entityId}></option>`;
-            })}
-          </datalist>
-        `;
+        this._actions(inner, canWrite && !uncontrolled);
+
+        root.appendChild(styleNode());
+        root.appendChild(container);
+      }
+
+      _yamlBlock() {
+        var self = this;
+        return h("div", { class: "section" },
+          h("h4", {}, "Generated YAML"),
+          h("pre", { class: "yaml", text: this._yamlOut }),
+          h("div", { class: "row" },
+            h("button", {
+              class: "small", type: "button", text: "Copy YAML",
+              onclick: function () { self._copyYaml(); }
+            })));
+      }
+
+      _actions(inner, canWrite) {
+        var self = this;
+        var actions = h("div", { class: "actions" });
+        if (canWrite) {
+          var save = h("button", {
+            class: "primary", type: "button", text: "Save",
+            disabled: !this._dirty,
+            onclick: function () { self._save(); }
+          });
+          actions.appendChild(save);
+        } else {
+          actions.appendChild(h("button", {
+            class: "primary", type: "button", text: "Generate YAML",
+            onclick: function () {
+              self._yamlOut = self._buildYaml();
+              self._render();
+            }
+          }));
+        }
+        actions.appendChild(h("button", {
+          class: "small", type: "button", text: "Reload config",
+          onclick: function () { self._reload(); }
+        }));
+        actions.appendChild(h("button", {
+          class: "small", type: "button", text: "Copy YAML",
+          onclick: function () { self._copyYaml(); }
+        }));
+        actions.appendChild(h("span", { class: "status" }, "version " + EditorVersion));
+        inner.appendChild(actions);
       }
     }
 
@@ -1911,22 +2297,13 @@ run();
     STATUS_MESSAGE("Editor card registered");
   }
 
-  // wait for HA's Lit classes to exist before defining the card
-  var attempts = 0;
-  var wait_timer = setInterval(function () {
-    attempts++;
-    if (customElements.get("hui-view") || customElements.get("hui-masonry-view")) {
-      clearInterval(wait_timer);
-      try {
-        defineEditor();
-      } catch (err) {
-        console.error("Animated Background: failed to register editor card", err);
-      }
-    } else if (attempts > 240) {
-      clearInterval(wait_timer);
-      console.warn("Animated Background: editor card not registered, HA frontend elements never appeared");
-    }
-  }, 500);
+  // no polling wait: the editor is plain DOM and defines its custom
+  // element immediately; HA's Lit classes are irrelevant to it now
+  try {
+    defineEditor();
+  } catch (err) {
+    console.error("Animated Background: failed to register editor card", err);
+  }
 
   // exposed for testing
   window.__animatedBackgroundEditor = {
@@ -1934,16 +2311,24 @@ run();
     linesToUrlValue: linesToUrlValue,
     urlValueToLines: urlValueToLines,
     textToList: textToList,
+    listToText: listToText,
+    stateMapToRows: stateMapToRows,
+    rowsToStateMap: rowsToStateMap,
     subFormFromConfig: subFormFromConfig,
     subConfigFromForm: subConfigFromForm,
     formFromConfig: formFromConfig,
     configFromForm: configFromForm,
-    configToYaml: configToYaml
+    viewIdentity: viewIdentity,
+    configToYaml: configToYaml,
+    assignmentsToYaml: assignmentsToYaml,
+    yamlScalar: yamlScalar,
+    yamlMapLines: yamlMapLines,
+    yamlBlock: yamlBlock
   };
 })();
 
 console.info(
-  '%c ANIMATED-BACKGROUND %c v1.1.0-beta.1 ',
+  '%c ANIMATED-BACKGROUND %c v1.1.0-beta.2 ',
   'color: white; background: #526ecd; font-weight: 700;',
   'color: white; background: #1c1c1c; font-weight: 700;'
 );

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -1469,7 +1469,7 @@ run();
   function defineEditor() {
     if (customElements.get("animated-background-editor")) return;
 
-    var EditorVersion = "v1.1.0-beta.2";
+    var EditorVersion = "v1.1.0";
 
     class AnimatedBackgroundEditor extends HTMLElement {
       constructor() {
@@ -2344,7 +2344,7 @@ run();
 })();
 
 console.info(
-  '%c ANIMATED-BACKGROUND %c v1.1.0-beta.2 ',
+  '%c ANIMATED-BACKGROUND %c v1.1.0 ',
   'color: white; background: #526ecd; font-weight: 700;',
   'color: white; background: #1c1c1c; font-weight: 700;'
 );

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -837,3 +837,9 @@ function restart() {
 }
 
 run();
+
+console.info(
+  '%c ANIMATED-BACKGROUND %c v1.0.0 ',
+  'color: white; background: #526ecd; font-weight: 700;',
+  'color: white; background: #1c1c1c; font-weight: 700;'
+);

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -441,13 +441,19 @@ function renderBackgroundHTML() {
 
   Previous_Config = current_config;
 
-  if (current_config.refresh_interval && !Refresh_Timer) {
+  // refresh keys resolve with a root fallback, same as opacity,
+  // transparent_panel and overlay — a group-driven view must inherit a
+  // root-level refresh_interval instead of silently getting none
+  var refresh_interval = current_config.refresh_interval !== undefined
+    ? current_config.refresh_interval
+    : (Animated_Config ? Animated_Config.refresh_interval : undefined);
+  if (refresh_interval && !Refresh_Timer) {
     Refresh_Timer = setInterval(function() {
       Previous_State = null;
       Previous_Url = null;
       renderBackgroundHTML();
-    }, current_config.refresh_interval * 60 * 1000);
-  } else if (!current_config.refresh_interval) {
+    }, refresh_interval * 60 * 1000);
+  } else if (!refresh_interval) {
     clearRefreshTimer();
   }
 
@@ -790,7 +796,12 @@ function run() {
             var entity_data = Haobj.states[current_config.entity];
             var current_last_updated = entity_data ? entity_data.last_updated : null;
             var state_changed = Previous_State != current_state;
-            var force_refresh = current_config.refresh_on_update && current_last_updated !== Previous_Last_Updated;
+            // root fallback here too: refresh_on_update set at root must
+            // reach group-driven views, not just root-config views
+            var refresh_on_update = current_config.refresh_on_update !== undefined
+              ? current_config.refresh_on_update
+              : (Animated_Config ? Animated_Config.refresh_on_update : false);
+            var force_refresh = refresh_on_update && current_last_updated !== Previous_Last_Updated;
             if (state_changed || force_refresh) {
               if (force_refresh && !state_changed) {
                 Previous_State = null;

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -17,6 +17,7 @@ var View_Loaded = false;
 var Meme_Remover = null;
 var Meme_Count = 0;
 var Refresh_Timer = null;
+var Wait_Interval = null;
 var Opacity = 99;
 
 //state tracking variables
@@ -196,7 +197,9 @@ function currentConfig() {
     }
 
     if (return_config) {
-      if (return_config.entity) {
+      // state_url may be absent while entity is set (half-finished config);
+      // indexing it would throw on every poll.
+      if (return_config.entity && return_config.state_url) {
         var current_state = getEntityState(return_config.entity);
         var current_url = return_config.state_url[current_state];
         if (current_url) {
@@ -542,6 +545,7 @@ function renderBackgroundHTML() {
         STATUS_MESSAGE("Applying default background", true);
       }
       var style = document.createElement("style");
+      style.id = "animated-bg-style";
       style.innerHTML = `
       .bg-video{
           min-width: 100vw; 
@@ -614,6 +618,8 @@ function renderBackgroundHTML() {
     }  // <-- this closes the if (state_url != "" && Hui) block
 
   // transparent for top Panel - evaluated on every render
+  // Reachable with Hui unresolved (e.g. provideHass during startup), so gate first.
+  if (!Hui || !Hui.shadowRoot) return;
   // Fall back to root Animated_Config for top-level settings not present in group/view configs
   var transparent_panel = current_config.transparent_panel !== undefined ? current_config.transparent_panel : (Animated_Config ? Animated_Config.transparent_panel : false);
   if (transparent_panel) {
@@ -725,6 +731,7 @@ function processDefaultBackground(temp_enabled) {
 function clearMemes() {
   clearInterval(Meme_Remover);
   Meme_Remover = null;
+  Meme_Count = 0;
 }
 
 function clearRefreshTimer() {
@@ -755,8 +762,10 @@ function cleanupDOM() {
   if (Root && Root.shadowRoot) {
     var oldDiv = Root.shadowRoot.getElementById('background-video');
     if (oldDiv) oldDiv.remove();
-    var oldStyles = Root.shadowRoot.querySelectorAll('style');
-    oldStyles.forEach(function(s) { s.remove(); });
+    // Remove only our own style element. The shadow root also holds Home
+    // Assistant's stylesheets (and card-mod's) - those must survive.
+    var ownStyle = Root.shadowRoot.getElementById('animated-bg-style');
+    if (ownStyle) ownStyle.remove();
   }
   if (Hui && Hui.shadowRoot) {
     var panelStyle = Hui.shadowRoot.getElementById('animated-bg-panel-style');
@@ -783,7 +792,14 @@ function run() {
 
   //subscribe to hass object to detect state changes
   if (!Haobj) {
-    document.querySelector("home-assistant").provideHass({
+    var ha_el = document.querySelector("home-assistant");
+    if (!ha_el) {
+      // run() fires at load, possibly before Home Assistant mounts.
+      // restart()'s poll loop waits for exactly this.
+      restart();
+      return;
+    }
+    ha_el.provideHass({
       set hass(value) {
         if (Haobj && Haobj.panelUrl != value.panelUrl) {
           restart();
@@ -856,8 +872,11 @@ function run() {
 function restart() {
   cleanupDOM();
   clearRefreshTimer();
-  clearInterval(wait_interval);
-  var wait_interval = setInterval(() => {
+  if (Wait_Interval) {
+    clearInterval(Wait_Interval);
+    Wait_Interval = null;
+  }
+  Wait_Interval = setInterval(() => {
     getVars()
     if (Hui) {
       Previous_Entity = null;
@@ -868,7 +887,8 @@ function restart() {
       clearMemes();
       View_Observer.disconnect();
       run();
-      clearInterval(wait_interval);
+      clearInterval(Wait_Interval);
+      Wait_Interval = null;
     }
   }, 200);
 }

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -1413,7 +1413,12 @@ run();
         }
       });
     }
-    (children || []).forEach(function (c) {
+    // children may be an array, a single node/string, or varargs —
+    // callers use all three styles
+    var kids = children === undefined || children === null
+      ? []
+      : (Array.isArray(children) ? children : Array.prototype.slice.call(arguments, 2));
+    kids.forEach(function (c) {
       if (c === null || c === undefined) return;
       node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
     });

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -1941,3 +1941,9 @@ run();
     configToYaml: configToYaml
   };
 })();
+
+console.info(
+  '%c ANIMATED-BACKGROUND %c v1.1.0-beta.1 ',
+  'color: white; background: #526ecd; font-weight: 700;',
+  'color: white; background: #1c1c1c; font-weight: 700;'
+);

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -1750,27 +1750,54 @@ run();
       // options, so re-renders cannot fight the selected state (§2.6)
       _select(value, options, onchange) {
         var HaSelect = customElements.get("ha-select");
-        var sel;
         if (HaSelect) {
-          sel = document.createElement("ha-select");
+          var sel = document.createElement("ha-select");
+          // HA 2026.2 rewrote ha-select from mwc to a ha-dropdown base: it
+          // fires "selected" (new value in detail.value) instead of
+          // "change", never updates its own value property, and its menu
+          // only reacts to ha-dropdown-item children. Older builds are
+          // mwc-based and need ha-list-item + "change".
+          var modern = !!customElements.get("ha-dropdown-item");
+          var itemTag = modern ? "ha-dropdown-item" : "ha-list-item";
           options.forEach(function (o) {
-            var item = document.createElement("ha-list-item");
+            var item = document.createElement(itemTag);
             item.value = o[0];
             item.textContent = o[1];
+            if (modern && o[0] === value) item.selected = true;
             sel.appendChild(item);
           });
-        } else {
-          sel = document.createElement("select");
-          options.forEach(function (o) {
-            var opt = document.createElement("option");
-            opt.value = o[0];
-            opt.textContent = o[1];
-            sel.appendChild(opt);
-          });
+          sel.value = value;
+          // mwc resolves value against its rendered item list during its
+          // own upgrade; re-assert after so the assignment cannot be lost
+          if (sel.updateComplete && typeof sel.updateComplete.then === "function") {
+            sel.updateComplete.then(function () { sel.value = value; });
+          }
+          if (modern) {
+            sel.addEventListener("selected", function (e) {
+              var next = e.detail && e.detail.value !== undefined
+                ? e.detail.value
+                : e.target.value;
+              if (next === value) return; // initial sync / same-value pick
+              onchange(next);
+            });
+          } else {
+            sel.addEventListener("change", function (e) { onchange(e.target.value); });
+          }
+          // mwc's menu "closed" event bubbles composed and can be mistaken
+          // for a dialog dismissal by an ancestor; HA stops it too
+          sel.addEventListener("closed", function (e) { e.stopPropagation(); });
+          return sel;
         }
-        sel.value = value;
-        sel.addEventListener("change", function (e) { onchange(e.target.value); });
-        return sel;
+        var native = document.createElement("select");
+        options.forEach(function (o) {
+          var opt = document.createElement("option");
+          opt.value = o[0];
+          opt.textContent = o[1];
+          native.appendChild(opt);
+        });
+        native.value = value;
+        native.addEventListener("change", function (e) { onchange(e.target.value); });
+        return native;
       }
 
       _entityPicker(value, onchange) {

--- a/dist/animated-background.js
+++ b/dist/animated-background.js
@@ -216,6 +216,15 @@ function currentConfig() {
 }
 
 //logic for checking if enabled in configuration
+// Precedence (documented in the README's Access section):
+//   1. Exclusions always win: a match on any excluded_users /
+//      excluded_devices list (root or view/group config) disables the
+//      background no matter what else is configured.
+//   2. An explicit enabled: true/false on the view/group config applies
+//      next - it can override inclusion lists, never exclusions.
+//   3. Inclusion lists are allowlists: if any included_users /
+//      included_devices list is configured, the current user or device
+//      must match at least one of them.
 function enabled() {
   var temp_enabled = false;
   if (Animated_Config) {
@@ -238,97 +247,55 @@ function enabled() {
     return false;
   }
 
-  //Root configuration exceptions
-  if (Animated_Config.excluded_devices) {
-    if (Animated_Config.excluded_devices.some(deviceIncluded)) {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current device is excluded", null, true);
-        temp_enabled = false;
-      }
-    }
+  // 1. Exclusions win - evaluated first, short-circuits everything below.
+  if (Animated_Config.excluded_devices && Animated_Config.excluded_devices.some(deviceIncluded)) {
+    DEBUG_MESSAGE("Current device is excluded", null, true);
+    return false;
+  }
+  if (Animated_Config.excluded_users && Animated_Config.excluded_users.map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase())) {
+    DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is excluded", null, true);
+    return false;
+  }
+  if (current_config.excluded_devices && current_config.excluded_devices.some(deviceIncluded)) {
+    DEBUG_MESSAGE("Current device is excluded", null, true);
+    return false;
+  }
+  if (current_config.excluded_users && current_config.excluded_users.map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase())) {
+    DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is excluded", null, true);
+    return false;
   }
 
-  if (Animated_Config.excluded_users) {
-    if (Animated_Config.excluded_users.map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase())) {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is excluded", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
-  if (Animated_Config.included_users) {
-    if (Animated_Config.included_users.map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase())) {
-      temp_enabled = true;
-    }
-    else {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is not included", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
-  if (Animated_Config.included_devices) {
-    if (Animated_Config.included_devices.some(deviceIncluded)) {
-      temp_enabled = true;
-    }
-    else {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current device is not included", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
-  //Current config overrides (only does anything if curre_config and Animated_Config are different)
-  if (current_config.excluded_devices) {
-    if (current_config.excluded_devices.some(deviceIncluded)) {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current device is excluded", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
-  if (current_config.excluded_users) {
-    if (current_config.excluded_users.map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase())) {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is excluded", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
-  if (current_config.included_users) {
-    if (current_config.included_users.map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase())) {
-      temp_enabled = true;
-    }
-    else {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is not included", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
-  if (current_config.included_devices) {
-    if (current_config.included_devices.some(deviceIncluded)) {
-      temp_enabled = true;
-    }
-    else {
-      if (temp_enabled) {
-        DEBUG_MESSAGE("Current device is not included", null, true);
-        temp_enabled = false;
-      }
-    }
-  }
-
+  // 2. Explicit per-config switch.
   if (current_config.enabled == false) {
-    temp_enabled = false;
+    return false;
   }
   if (current_config.enabled == true) {
-    temp_enabled = true;
+    return true;
+  }
+
+  // 3. Inclusion lists act as allowlists: if any is configured, the user
+  //    or device must match at least one of them (root or per-config).
+  var has_inclusions =
+    (Animated_Config.included_users && Animated_Config.included_users.length) ||
+    (Animated_Config.included_devices && Animated_Config.included_devices.length) ||
+    (current_config.included_users && current_config.included_users.length) ||
+    (current_config.included_devices && current_config.included_devices.length);
+  if (has_inclusions) {
+    var user_matched =
+      (Animated_Config.included_users || []).map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase()) ||
+      (current_config.included_users || []).map(username => username.toLowerCase()).includes(Haobj.user.name.toLowerCase());
+    var device_matched =
+      (Animated_Config.included_devices || []).some(deviceIncluded) ||
+      (current_config.included_devices || []).some(deviceIncluded);
+    if (!user_matched && !device_matched) {
+      if (Animated_Config.included_users || current_config.included_users) {
+        DEBUG_MESSAGE("Current user: " + Haobj.user.name + " is not included", null, true);
+      }
+      if (Animated_Config.included_devices || current_config.included_devices) {
+        DEBUG_MESSAGE("Current device is not included", null, true);
+      }
+      return false;
+    }
   }
 
   return temp_enabled;


### PR DESCRIPTION
## Summary

- Overlay tinting feature: color/opacity layer over any background (image or video)
- Visual configuration editor card with full config coverage, rewritten as plain DOM
- Runtime hardening from code audit: stop deleting foreign styles, harden null paths and timers, numeric alpha handling, per-render style updates, live refresh-interval changes, iframe built via element properties with a double-load guard
- `enabled()` precedence: exclusions always win over inclusions, then explicit enabled flag, then inclusion-lists-as-allowlists
- Editor fixes for HA 2026.2+ (ha-select fires `selected` with `detail.value`, ha-dropdown-item children; native-input fallback for ha-textfield removal), refresh_interval/refresh_on_update root inheritance, editor blank-render fix
- README refresh, version bumped to v1.1.0

## Test plan

- [x] Overlay tint on image and video backgrounds, all editor controls
- [x] Visual editor across HA select eras (modern ha-dropdown, legacy mwc, native input)
- [x] Audit fixes P1-P11 verified via scenario harnesses (enabled() precedence end-to-end, dropdown eras, smoke tests)
- [x] Extended live testing on production HA instance